### PR TITLE
Changes the application database to Postgresql

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,8 @@ ruby '2.2.1'
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '4.2.0'
 # Use sqlite3 as the database for Active Record
-gem 'sqlite3'
+#gem 'sqlite3'
+gem 'pg'
 # Use SCSS for stylesheets
 gem 'sass-rails', '~> 5.0'
 # Use Uglifier as compressor for JavaScript assets

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,6 +124,7 @@ GEM
     multi_xml (0.5.5)
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
+    pg (0.18.2)
     rack (1.6.4)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -179,7 +180,6 @@ GEM
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       sprockets (>= 2.8, < 4.0)
-    sqlite3 (1.3.10)
     test-factory (0.5.3)
       watir-webdriver (>= 0.6.4)
     therubyracer (0.12.2)
@@ -223,11 +223,11 @@ DEPENDENCIES
   faker (= 1.4.2)
   jbuilder (~> 2.0)
   jquery-rails
+  pg
   rails (= 4.2.0)
   ruby_spark
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)
-  sqlite3
   test-factory (~> 0.5.3)
   therubyracer
   turbolinks

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,26 +1,29 @@
-# SQLite version 3.x
-#   gem 'activerecord-jdbcsqlite3-adapter'
-#
-# Configure Using Gemfile
-# gem 'activerecord-jdbcsqlite3-adapter'
-#
 default: &default
-  adapter: sqlite3
+  adapter: postgresql
+  host: localhost
+  encoding: unicode
+  pool: 5
+  timeout: 5000
+  # Kinda goes without saying, but you must actually create 
+  # this user with this password for this to work...
+  username: ohmbrewer
+  password: foobar
 
 development:
   <<: *default
-  database: db/development.sqlite3
+  database: ohmbrewer_dev
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
-# Do not set this db to the same as development or production.
+# Do not set this db to the same as development or production,
+# ya idjit.
 test: &test
   <<: *default
-  database: db/test.sqlite3
+  database: ohmbrewer_test
 
 production:
   <<: *default
-  database: db/production.sqlite3
+  database: ohmbrewer
 
 cucumber:
   <<: *test

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -13,6 +13,9 @@
 
 ActiveRecord::Schema.define(version: 20150501031419) do
 
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
   create_table "delayed_jobs", force: :cascade do |t|
     t.integer  "priority",               default: 0, null: false
     t.integer  "attempts",               default: 0, null: false
@@ -27,7 +30,7 @@ ActiveRecord::Schema.define(version: 20150501031419) do
     t.datetime "updated_at"
   end
 
-  add_index "delayed_jobs", ["priority", "run_at"], name: "delayed_jobs_priority"
+  add_index "delayed_jobs", ["priority", "run_at"], name: "delayed_jobs_priority", using: :btree
 
   create_table "users", force: :cascade do |t|
     t.string   "name",            limit: 255
@@ -39,6 +42,6 @@ ActiveRecord::Schema.define(version: 20150501031419) do
     t.boolean  "admin",                       default: false
   end
 
-  add_index "users", ["email"], name: "index_users_on_email", unique: true
+  add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree
 
 end


### PR DESCRIPTION
@Ohmbrewer/owners This is pretty small commit, but it's important. This swaps us off of SQLite3 and onto Postgresql. We're doing this because while SQLite3 is fairly serviceable for doing simple development work, it isn't meant to be a production database. It would be good to get this change in now before we get much further down the road.

You will have to do some installation work in your VM unfortunately. However, I've done it myself and I've created a Gist of the process for you to follow: https://gist.github.com/kyleoliveira/73a81eba44a85fc468ab If it weren't for the parts you have to do in the psql client, you'd be able to run it as a BASH script. As it is, just follow those steps and you should be good to go. If you run into problems for whatever reason, just let me know and we can work through them.

I'm going to leave this open for a few days in case there are any objections. If I don't hear anything back from you guys, I'll merge it to master Monday or Tuesday.
