### PR TITLE
Adds a status dashboard.

### DIFF
--- a/app/assets/javascripts/dashboard.coffee
+++ b/app/assets/javascripts/dashboard.coffee
@@ -1,0 +1,29 @@
+$ ->
+  setTimeout (->
+    source = new EventSource('/status_updates/pumps')
+    source.addEventListener 'pump_status_update', (e) ->
+      # Get the status update into JSON format. For some reason we need to parse it twice.
+      status = JSON.parse(JSON.parse(e.data))
+      # Figure out the unique ID of the status update row.
+      row_id = 'pump-status-' + status.device_id + '-' + status.pump_id
+      # Build the row's HTML.
+      html = """
+<tr id="#{row_id}">
+  <td>#{status.device_id}</td>
+  <td>#{status.pump_id}</td>
+  <td>#{status.state}</td>
+  <td>#{status.stop_time}</td>
+  <td>#{status.speed}</td>
+</tr>
+      """
+
+      # If the Pump has already sent an update before, remove the old update.
+      if $("##{row_id}").length
+        $("##{row_id}").remove()
+
+      # Finally, add the new row.
+      $('#pump_statuses_dashboard').append($(html))
+      return
+    return
+  ), 1
+  return

--- a/app/controllers/jobs_controller.rb
+++ b/app/controllers/jobs_controller.rb
@@ -3,9 +3,13 @@ class JobsController < ApplicationController
   # == Enabled Before Filters ==
 
   before_action :logged_in_user,
-                only: [:ping]
+                only: [:ping, :dashboard]
 
   # == Routes ==
+
+  def dashboard
+    @pump_statuses = PumpStatus.paginate(page: params[:page])
+  end
 
   def ping
     result = PingJob.new(*params).perform_now

--- a/app/controllers/status_updates_controller.rb
+++ b/app/controllers/status_updates_controller.rb
@@ -1,0 +1,34 @@
+require 'eventstreamer/sse'
+
+class StatusUpdatesController < ApplicationController
+
+  include ActionController::Live
+
+  # == Enabled Before Filters ==
+
+  before_action :logged_in_user,
+                only: [:pumps]
+
+  # == Routes ==
+
+  def pumps
+    # SSE expects the `text/event-stream` content type
+    response.headers['Cache-Control'] = 'no-cache'
+    response.headers['Content-Type'] = 'text/event-stream'
+
+    sse = EventStreamer::SSE.new(response.stream)
+
+    begin
+      PumpStatus.on_change do |data|
+        sse.write(data, PumpStatus.event_channel)
+      end
+    rescue IOError
+      # When the client disconnects, we'll get an IOError on write
+    ensure
+      sse.close
+    end
+
+    render nothing: true
+  end
+
+end

--- a/app/models/pump_status.rb
+++ b/app/models/pump_status.rb
@@ -5,10 +5,22 @@ class PumpStatus < ActiveRecord::Base
   validates :pump_id, presence: true
   validates :state, presence: true
 
+  after_save   :notify_state_change
+  after_create :notify_state_change
+
   def initialize(attributes = nil, options = {})
     super self.class.parse_incoming_pump_status(attributes), options
   end
 
+  def to_sse_json
+    JSON.generate({
+                      device_id:  device_id,
+                      pump_id:    pump_id,
+                      state:      state,
+                      speed:      speed,
+                      stop_time:  stop_time
+                  })
+  end
 
   class << self
 
@@ -25,9 +37,27 @@ class PumpStatus < ActiveRecord::Base
       }
     end
 
+    def on_change
+      PumpStatus.connection.execute 'LISTEN pump_statuses'
+      loop do
+        PumpStatus.connection.raw_connection.wait_for_notify do |event, pid, pump_status|
+          yield pump_status
+        end
+      end
+    ensure
+      PumpStatus.connection.execute 'UNLISTEN pump_statuses'
+    end
+
+    def event_channel
+      {event: 'pump_status_update'}
+    end
+
   end
 
-
   private
+
+    def notify_state_change
+      PumpStatus.connection.execute "NOTIFY pump_statuses, '#{to_sse_json}'"
+    end
 
 end

--- a/app/views/jobs/_pump_statuses_dashboard.html.erb
+++ b/app/views/jobs/_pump_statuses_dashboard.html.erb
@@ -1,0 +1,20 @@
+<div class="list-group panel">
+    <div class="table-responsive">
+        <h4 class="list-group-item list-group-item-success">Pumps</h4>
+        <table id="pump_statuses_dashboard" class="pump_statuses table table-hover table-striped">
+          <thead>
+            <tr>
+              <th>Device ID</th>
+              <th>Pump ID</th>
+              <th>State</th>
+              <th>Designated Stop Time</th>
+              <th>Speed</th>
+            </tr>
+          </thead>
+          <tbody>
+          <%= render @pump_statuses %>
+          </tbody>
+        </table>
+
+    </div>
+</div>

--- a/app/views/jobs/dashboard.html.erb
+++ b/app/views/jobs/dashboard.html.erb
@@ -1,23 +1,6 @@
-<% provide(:title, 'Current Pump Statuses') %>
+<% provide(:title, 'Dashboard') %>
 <h1>
-    Current Pump Statuses
+    Dashboard
 </h1>
-
-<div class="table-responsive">
-
-    <table id="pump_statuses_dashboard" class="pump_statuses table table-hover table-striped">
-      <thead>
-        <tr>
-          <th>Device ID</th>
-          <th>Pump ID</th>
-          <th>State</th>
-          <th>Designated Stop Time</th>
-          <th>Speed</th>
-        </tr>
-      </thead>
-      <tbody>
-      <%= render @pump_statuses %>
-      </tbody>
-    </table>
-
-</div>
+<p>Status updates for jobs assigned to Equipment in your Brewhouse are shown below.</p>
+<%= render 'jobs/pump_statuses_dashboard' %>

--- a/app/views/jobs/dashboard.html.erb
+++ b/app/views/jobs/dashboard.html.erb
@@ -1,0 +1,23 @@
+<% provide(:title, 'Current Pump Statuses') %>
+<h1>
+    Current Pump Statuses
+</h1>
+
+<div class="table-responsive">
+
+    <table id="pump_statuses_dashboard" class="pump_statuses table table-hover table-striped">
+      <thead>
+        <tr>
+          <th>Device ID</th>
+          <th>Pump ID</th>
+          <th>State</th>
+          <th>Designated Stop Time</th>
+          <th>Speed</th>
+        </tr>
+      </thead>
+      <tbody>
+      <%= render @pump_statuses %>
+      </tbody>
+    </table>
+
+</div>

--- a/app/views/pump_statuses/_pump_status.html.erb
+++ b/app/views/pump_statuses/_pump_status.html.erb
@@ -1,0 +1,7 @@
+<tr id="pump-status-<%= pump_status.device_id %>-<%= pump_status.pump_id %>">
+  <td><%= pump_status.device_id %></td>
+  <td><%= pump_status.pump_id %></td>
+  <td><%= pump_status.state %></td>
+  <td><%= pump_status.stop_time %></td>
+  <td><%= pump_status.speed %></td>
+</tr>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -4,10 +4,10 @@ Rails.application.configure do
   # In the development environment your application's code is reloaded on
   # every request. This slows down response time but is perfect for development
   # since you don't have to restart the web server when you make code changes.
-  config.cache_classes = false
+  config.cache_classes = true #false
 
   # Do not eager load code on boot.
-  config.eager_load = false
+  config.eager_load = true #false
 
   # Show full error reports and disable caching.
   config.consider_all_requests_local       = true

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,11 +25,17 @@ Rails.application.routes.draw do
   scope :jobs, controller: :jobs, shallow: true do
     post 'ping'
     post 'pump'
+    get  'dashboard'
   end
 
   # Provide webhooks for our HOPS... HOPhooks, if you will...
   scope '/hooks/v1', :controller => :hooks do
     post :pumps
+  end
+
+  # Paths under this controller are used with SSE to stream status updates
+  scope :status_updates, controller: :status_updates, shallow: true do
+    get :pumps
   end
 
 end

--- a/lib/eventstreamer/sse.rb
+++ b/lib/eventstreamer/sse.rb
@@ -1,0 +1,30 @@
+require 'json'
+
+module EventStreamer
+
+  # A class of Objects that knows how to format messages as Server-Sent Events
+  # and emits those messages to the live stream
+  # @see http://tenderlovemaking.com/2012/07/30/is-it-live.html
+  class SSE
+
+    # @param [Stream] io A streamable object
+    def initialize(io)
+      @io = io
+    end
+
+    # @param [Object] object An object that should be able to be formatted for SSE's
+    # @param [Object] options Additional options that can be written with the SSE
+    def write(object, options = {})
+      options.each do |k,v|
+        @io.write "#{k}: #{v}\n"
+      end
+      @io.write "data: #{JSON.dump(object)}\n\n"
+    end
+
+    # Closes the IO stream
+    def close
+      @io.close
+    end
+  end
+
+end


### PR DESCRIPTION
@Ohmbrewer/owners 
This adds a super simple dashboard at /jobs/dashboard . Existing Pump Status entries are displayed in a table. Each Device ID / Pump ID pair represents a single piece of Equipment, so the assumption here is that whenever a new Pump Status comes in with a given pair, we want to remove the old entry from the displayed table (if it exists) and add a new row.

Updates are asynchronously added to the page via Coffeescript. Basically, when an update is saved to the database (such as when the Rhizome updates Ohmbrewer), the database sends an update over a Server-Sent Event stream saying "Hey! I've got an update folks!". That aforementioned Coffeescript is listening to the stream and modifies the page when it detects the appropriate event.

There's definitely room for improvement (for example, we probably don't want to actually delete status updates, but rather "deactive" them using an additional column or something), but this should be a good first step as figuring out how to actually do SSE's in Rails was non-trivial. Check out http://tenderlovemaking.com/2012/07/30/is-it-live.html for the gist of it, but I also pulled together information from other sources online.

I'm going to leave this Pull Request up until this week's meeting and merge it in unless someone objects.
