### PR TITLE
Implements Equipment support

### DIFF
--- a/app/assets/javascripts/equipment.coffee
+++ b/app/assets/javascripts/equipment.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/javascripts/recirculating_infusion_mash_systems.coffee
+++ b/app/assets/javascripts/recirculating_infusion_mash_systems.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/javascripts/thermostats.coffee
+++ b/app/assets/javascripts/thermostats.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/equipment.scss
+++ b/app/assets/stylesheets/equipment.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the Equipment controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/assets/stylesheets/recirculating_infusion_mash_systems.scss
+++ b/app/assets/stylesheets/recirculating_infusion_mash_systems.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the RecirculatingInfusionMashSystems controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/assets/stylesheets/thermostats.scss
+++ b/app/assets/stylesheets/thermostats.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the Thermostats controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/equipments_controller.rb
+++ b/app/controllers/equipments_controller.rb
@@ -1,0 +1,138 @@
+class EquipmentsController < ApplicationController
+
+  # == Enabled Before Filters ==
+
+  before_action :logged_in_user
+  before_action :admin_user,
+                only: :destroy
+  before_action :set_type
+  before_action :set_equipment,
+                only: [:show, :edit, :update, :destroy]
+  before_action :set_rhizome,
+                only: [:new, :create]
+
+  # == Routes ==
+
+  def index
+    @equipments = type_class.paginate(page: params[:page])
+  end
+
+  def show
+    if params[:id] == 'destroy_multiple'
+      destroy_multiple
+    end
+  end
+
+  def new
+    if @type == 'Equipment'
+      flash[:danger] = 'You must be more specific about the type of Equipment you wish to create.'
+      redirect_to rhizomes_path
+    end
+    @equipment = type_class.new
+  end
+
+  def edit; end
+
+  def create
+    @equipment = Equipment.new(equipment_params)
+    if @equipment.valid?
+      @rhizome.equipments << @equipment
+      msg = "#{@equipment.type.titlecase} successfully added to #{@rhizome.name}!"
+      if @equipment.save
+        flash[:success] = msg
+        redirect_to rhizomes_path
+      else
+        render action: 'new'
+      end
+    else
+      render action: 'new'
+    end
+  end
+
+  def update
+    if @equipment.update(equipment_params)
+      flash[:success] = "#{@equipment.type.titlecase} successfully updated!"
+      redirect_to rhizomes_path
+    else
+      render action: 'edit'
+    end
+  end
+
+  def destroy
+    if params[:id] != 'destroy_multiple'
+      msg = "#{@type.titlecase} removed from #{@equipment.rhizome.name}!"
+      @equipment.destroy
+      flash[:success] = msg
+      redirect_to rhizomes_path
+    else
+      destroy_multiple
+    end
+  end
+
+  def destroy_multiple
+    ids = Equipment.equipment_types
+                   .collect { |t| params[t.pluralize.underscore] }
+    pre = Equipment.where(id: ids)
+    Equipment.destroy_all(id: ids)
+    post = pre.where(id: ids)
+
+    case post.length
+      when 0
+        flash[:success] = 'Equipment removed!'
+      when pre.length
+        flash[:danger] = 'Equipment removal failed!'
+      else
+        flash[:warning] = "Something strange happened... #{pre.length - post.length} pieces of Equipment weren't removed."
+    end
+
+    redirect_to rhizomes_url
+  end
+
+  private
+
+    def equipment_params
+      p = params.require(type.underscore.to_sym)
+                .permit(:type, :control_pin, :power_pin,
+                        :data_pin, :onewire_id, :rhizome)
+      unless p[:rhizome].nil?
+        unless p[:rhizome].is_a? Rhizome
+          p[:rhizome] = Rhizome.find(p[:rhizome])
+        end
+      end
+      p
+    end
+
+    def set_equipment
+      unless params[:id] == 'destroy_multiple'
+        @equipment = type_class.find(params[:id])
+        @rhizome = @equipment.rhizome
+      end
+    end
+
+    def set_type
+      @type = type
+    end
+
+    def set_rhizome
+      # Coming from an Equipment page
+      unless params[type.underscore.to_sym].nil?
+        unless params[type.underscore.to_sym][:rhizome].nil?
+          @rhizome = Rhizome.find(params[type.underscore.to_sym][:rhizome].to_i)
+        end
+      end
+
+      # Coming from the Rhizome pages
+      unless params[:rhizome].nil?
+        @rhizome = Rhizome.find(params[:rhizome].to_i)
+      end
+    end
+
+    def type
+      Equipment.equipment_types.include?(params[:type]) ? params[:type] : 'Equipment'
+    end
+
+    def type_class
+      type.constantize
+    end
+
+end

--- a/app/controllers/recirculating_infusion_mash_systems_controller.rb
+++ b/app/controllers/recirculating_infusion_mash_systems_controller.rb
@@ -1,0 +1,124 @@
+class RecirculatingInfusionMashSystemsController < ApplicationController
+
+  # == Enabled Before Filters ==
+
+  before_action :logged_in_user
+  before_action :set_rims, only: [:show, :edit, :update, :destroy]
+  before_action :set_rhizome,
+                only: [:new, :create]
+
+
+  def index
+    @recirculating_infusion_mash_systems = RecirculatingInfusionMashSystem.paginate(page: params[:page])
+  end
+
+  def show
+    if params[:id] == 'destroy_multiple'
+      destroy_multiple
+    end
+  end
+
+  def new
+    @recirculating_infusion_mash_system = RecirculatingInfusionMashSystem.new
+    @recirculating_infusion_mash_system.build_subsystems
+  end
+
+  def edit; end
+
+  def create
+    @recirculating_infusion_mash_system = RecirculatingInfusionMashSystem.new(rims_params)
+
+    if @recirculating_infusion_mash_system.valid?
+      @rhizome.recirculating_infusion_mash_systems << @recirculating_infusion_mash_system
+      msg = "RIMS successfully added to #{@rhizome.name}!"
+      if @recirculating_infusion_mash_system.save
+        flash[:success] = msg
+        redirect_to rhizomes_path
+      else
+        render action: 'new'
+      end
+    else
+      render action: 'new'
+    end
+  end
+
+  def update
+    if @recirculating_infusion_mash_system.update(rims_params)
+      flash[:success] = 'RIMS successfully updated!'
+      redirect_to @recirculating_infusion_mash_system
+    else
+      render 'edit'
+    end
+  end
+
+  def destroy
+    if params[:id] != 'destroy_multiple'
+      msg = "RIMS removed from #{@recirculating_infusion_mash_system.rhizome.name}!"
+      @recirculating_infusion_mash_system.destroy
+      flash[:success] = msg
+      redirect_to rhizomes_path
+    else
+      destroy_multiple
+    end
+  end
+
+  def destroy_multiple
+    pre = RecirculatingInfusionMashSystem.where(id: params[:recirculating_infusion_mash_systems])
+    RecirculatingInfusionMashSystem.destroy_all(id: params[:recirculating_infusion_mash_systems])
+    post = pre.where(id: params[:recirculating_infusion_mash_systems])
+
+    case post.length
+      when 0
+        flash[:success] = 'RIMS removed!'
+      when pre.length
+        flash[:danger] = 'RIMS removal failed!'
+      else
+        flash[:warning] = "Something strange happened... #{pre.length - post.length} pieces of RIMS equipment weren't removed."
+    end
+
+    redirect_to rhizomes_url
+  end
+
+  private
+  # Use callbacks to share common setup or constraints between actions.
+  def set_rims
+    unless params[:id] == 'destroy_multiple'
+      @recirculating_infusion_mash_system = RecirculatingInfusionMashSystem.find(params[:id]) unless params[:id].to_i.zero?
+      @rhizome = @recirculating_infusion_mash_system.rhizome
+    end
+  end
+
+  def set_rhizome
+    # Coming from a RIMS page
+    unless params[:recirculating_infusion_mash_system].nil?
+      unless params[:recirculating_infusion_mash_system][:rhizome].nil?
+        @rhizome = Rhizome.find(params[:recirculating_infusion_mash_system][:rhizome].to_i)
+      end
+    end
+
+    # Coming from the Rhizome pages
+    unless params[:rhizome].nil?
+      @rhizome = Rhizome.find(params[:rhizome].to_i)
+    end
+  end
+
+  # Never trust parameters from the scary internet, only allow the white list through.
+  def rims_params
+    p = params.require(:recirculating_infusion_mash_system)
+            .permit(:rhizome,
+                    tube_attributes: [
+                        :id,
+                        sensor_attributes: [:id, :onewire_id, :data_pin],
+                        element_attributes: [:id, :control_pin, :power_pin]
+                    ],
+                    safety_sensor_attributes: [:id, :onewire_id, :data_pin],
+                    recirculation_pump_attributes: [:id, :control_pin, :power_pin])
+    unless p[:rhizome].nil?
+      unless p[:rhizome].is_a? Rhizome
+        p[:rhizome] = Rhizome.find(p[:rhizome])
+      end
+    end
+    p
+  end
+  
+end

--- a/app/controllers/rhizomes_controller.rb
+++ b/app/controllers/rhizomes_controller.rb
@@ -43,7 +43,10 @@ class RhizomesController < ApplicationController
   end
 
   def destroy
-    if params[:rhizomes].nil?
+    if !params[:heating_elements].nil? || !params[:temperature_sensors].nil? ||
+       !params[:pumps].nil? || !params[:equipments].nil?
+      redirect_to controller: :equipments, action: :destroy_multiple, params: params
+    elsif params[:rhizomes].nil?
 
       if @rhizome.nil?
         flash[:danger] = 'No Rhizome selected!'

--- a/app/controllers/thermostats_controller.rb
+++ b/app/controllers/thermostats_controller.rb
@@ -1,0 +1,118 @@
+class ThermostatsController < ApplicationController
+
+  # == Enabled Before Filters ==
+
+  before_action :logged_in_user
+  before_action :set_thermostat, only: [:show, :edit, :update, :destroy]
+  before_action :set_rhizome,
+                only: [:new, :create]
+
+  def index
+    @thermostats = Thermostat.paginate(page: params[:page])
+  end
+
+  def show
+    if params[:id] == 'destroy_multiple'
+      destroy_multiple
+    end
+  end
+
+  def new
+    @thermostat = Thermostat.new
+    @thermostat.build_subsystems
+  end
+
+  def edit; end
+
+  def create
+    @thermostat = Thermostat.new(thermostat_params)
+
+    if @thermostat.valid?
+      @rhizome.thermostats << @thermostat
+      msg = "Thermostat successfully added to #{@rhizome.name}!"
+      if @thermostat.save
+        flash[:success] = msg
+        redirect_to rhizomes_path
+      else
+        render action: 'new'
+      end
+    else
+      render action: 'new'
+    end
+  end
+
+  def update
+    if @thermostat.update(thermostat_params)
+      flash[:success] = 'Thermostat successfully updated!'
+      redirect_to @thermostat
+    else
+      render 'edit'
+    end
+  end
+
+  def destroy
+    if params[:id] != 'destroy_multiple'
+      msg = "Thermostat removed from #{@thermostat.rhizome.name}!"
+      @thermostat.destroy
+      flash[:success] = msg
+      redirect_to rhizomes_path
+    else
+      destroy_multiple
+    end
+  end
+
+  def destroy_multiple
+    pre = Thermostat.where(id: params[:thermostats])
+    Thermostat.destroy_all(id: params[:thermostats])
+    post = pre.where(id: params[:thermostats])
+
+    case post.length
+      when 0
+        flash[:success] = 'Thermostat removed!'
+      when pre.length
+        flash[:danger] = 'Thermostat removal failed!'
+      else
+        flash[:warning] = "Something strange happened... #{pre.length - post.length} pieces of Thermostat weren't removed."
+    end
+
+    redirect_to rhizomes_url
+  end
+
+  private
+  # Use callbacks to share common setup or constraints between actions.
+  def set_thermostat
+    unless params[:id] == 'destroy_multiple'
+      @thermostat = Thermostat.find(params[:id]) unless params[:id].to_i.zero?
+      @rhizome = @thermostat.rhizome
+    end
+  end
+
+  def set_rhizome
+    # Coming from a Thermostat page
+    unless params[:thermostat].nil?
+      unless params[:thermostat][:rhizome].nil?
+        @rhizome = Rhizome.find(params[:thermostat][:rhizome].to_i)
+      end
+    end
+
+    # Coming from the Rhizome pages
+    unless params[:rhizome].nil?
+      @rhizome = Rhizome.find(params[:rhizome].to_i)
+    end
+  end
+
+  # Never trust parameters from the scary internet, only allow the white list through.
+  def thermostat_params
+    p = params.require(:thermostat)
+              .permit(:rhizome,
+                      sensor_attributes: [:id, :onewire_id, :data_pin],
+                      element_attributes: [:id, :control_pin, :power_pin])
+    unless p[:rhizome].nil?
+      unless p[:rhizome].is_a? Rhizome
+        p[:rhizome] = Rhizome.find(p[:rhizome])
+      end
+    end
+    p
+  end
+
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -12,4 +12,27 @@ module ApplicationHelper
     end
   end
 
+  def js_back_button(back_or_cancel=:back)
+    case back_or_cancel
+      when :back
+        link_to 'Back',
+                'javascript:history.back()',
+                class: 'btn btn-sm btn-primary',
+                alt: 'Back',
+                title: 'Back'
+      when :cancel
+        link_to 'Cancel',
+                'javascript:history.back()',
+                class: 'btn btn-sm btn-danger',
+                alt: 'Cancel',
+                title: 'Cancel'
+      else
+        link_to 'Back',
+                'javascript:history.back()',
+                class: 'btn btn-sm btn-primary',
+                alt: 'Back',
+                title: 'Back'
+    end
+  end
+
 end

--- a/app/helpers/equipments_helper.rb
+++ b/app/helpers/equipments_helper.rb
@@ -1,0 +1,42 @@
+module EquipmentsHelper
+
+  def sti_equipment_type_path(type = 'equipment', equipment = nil, action = nil)
+    send "#{format_sti(action, type, equipment)}_path", equipment
+  end
+
+  def format_sti(action, type, equipment)
+    action || equipment ? "#{format_action(action)}#{type.underscore}" : "#{type.underscore.pluralize}"
+  end
+
+  def format_action(action)
+    action ? "#{action}_" : ''
+  end
+
+  def rhizome_title_reference(rhizome, action)
+    if rhizome.nil?
+      ''
+    else
+      case action
+        when :add
+          "to #{rhizome.name}"
+        when :edit
+          "on #{rhizome.name}"
+        else
+          ''
+      end
+    end
+  end
+
+  def pins_list(equipment)
+    content_tag(:ul) do
+      if equipment.pins.length.zero?
+        content_tag(:li, 'Not Set')
+      else
+        equipment.pins.each do |k, v|
+          concat content_tag(:li, "#{k.titlecase}: #{v}")
+        end
+      end
+    end
+  end
+
+end

--- a/app/helpers/heating_elements_helper.rb
+++ b/app/helpers/heating_elements_helper.rb
@@ -1,0 +1,31 @@
+module HeatingElementsHelper
+
+  def heating_element_group_column(heating_element)
+    if heating_element.thermostat.nil?
+      content_tag(:td)
+    else
+      content_tag(:td) do
+        if heating_element.thermostat.recirculating_infusion_mash_system.nil?
+          thermostat_link(heating_element.thermostat)
+        else
+          concat thermostat_link(heating_element.thermostat)
+          concat rims_link(heating_element.thermostat.recirculating_infusion_mash_system)
+        end
+      end
+    end
+
+  end
+
+  def thermostat_link(thermostat)
+    content_tag(:p) do
+      link_to "Thermostat #{thermostat.rhizome_eid}", thermostat
+    end
+  end
+
+  def rims_link(rims)
+    content_tag(:p) do
+      link_to "RIMS #{rims.rhizome_eid}", rims
+    end
+  end
+
+end

--- a/app/helpers/pumps_helper.rb
+++ b/app/helpers/pumps_helper.rb
@@ -1,0 +1,17 @@
+module PumpsHelper
+
+  def pump_group_column(pump)
+    content_tag(:td) do
+      unless pump.recirculating_infusion_mash_system.nil?
+        rims_link(pump.recirculating_infusion_mash_system)
+      end
+    end
+  end
+
+  def rims_link(rims)
+    content_tag(:p) do
+      link_to "RIMS #{rims.rhizome_eid}", rims
+    end
+  end
+
+end

--- a/app/helpers/recirculating_infusion_mash_systems_helper.rb
+++ b/app/helpers/recirculating_infusion_mash_systems_helper.rb
@@ -1,0 +1,2 @@
+module RecirculatingInfusionMashSystemsHelper
+end

--- a/app/helpers/temperature_sensors_helper.rb
+++ b/app/helpers/temperature_sensors_helper.rb
@@ -1,0 +1,37 @@
+module TemperatureSensorsHelper
+
+  def temperature_sensor_group_column(temperature_sensor)
+    if temperature_sensor.thermostat.nil?
+      if temperature_sensor.recirculating_infusion_mash_system.nil?
+        content_tag(:td)
+      else
+        return content_tag(:td) do
+          rims_link(temperature_sensor.recirculating_infusion_mash_system)
+        end
+      end
+    else
+      return content_tag(:td) do
+        if temperature_sensor.thermostat.recirculating_infusion_mash_system.nil?
+          thermostat_link(temperature_sensor.thermostat)
+        else
+          concat thermostat_link(temperature_sensor.thermostat)
+          concat rims_link(temperature_sensor.thermostat.recirculating_infusion_mash_system)
+        end
+      end
+    end
+
+  end
+
+  def thermostat_link(thermostat)
+    content_tag(:p) do
+      link_to "Thermostat #{thermostat.rhizome_eid}", thermostat
+    end
+  end
+
+  def rims_link(rims)
+    content_tag(:p) do
+      link_to "RIMS #{rims.rhizome_eid}", rims
+    end
+  end
+
+end

--- a/app/helpers/thermostats_helper.rb
+++ b/app/helpers/thermostats_helper.rb
@@ -1,0 +1,2 @@
+module ThermostatsHelper
+end

--- a/app/models/equipment.rb
+++ b/app/models/equipment.rb
@@ -1,0 +1,36 @@
+class Equipment < ActiveRecord::Base
+
+  has_one :sprout, as: :sproutable, dependent: :destroy
+  has_one :rhizome, through: :sprout
+
+  # == Subclass scopes ==
+  # These scopes make so anything that references Equipment generally
+  # may also reference each of these subclasses specifically, automagically.
+  scope :pumps, -> { where(type: 'Pump') }
+  scope :heating_elements, -> { where(type: 'HeatingElement') }
+  scope :temperature_sensors, -> { where(type: 'TemperatureSensor') }
+
+  # == Serializers ==
+  # HashSerializer provides a way to convert the JSONB contents
+  # of the :pins column into a Hash object
+  serialize :pins, HashSerializer
+
+  def attached?
+    rhizome.nil?
+  end
+
+  def is_basic_equipment?
+    type == 'Equipment'
+  end
+
+  class << self
+
+    # TODO: Move this out into a table of available Equipment Types
+    # The list of supported Equipment types
+    def equipment_types
+      %w(Pump HeatingElement TemperatureSensor)
+    end
+
+  end
+
+end

--- a/app/models/heating_element.rb
+++ b/app/models/heating_element.rb
@@ -1,0 +1,34 @@
+require 'rhizome_sprout/rhizome_sprout'
+require 'validation_sets/relay_validations'
+
+class HeatingElement < Equipment
+  include RhizomeSprout
+  include RelayValidations
+
+  belongs_to :thermostat, validate: true, touch: true
+  belongs_to :recirculating_infusion_mash_system, validate: true,
+                                                  touch: true,
+                                                  foreign_key: :rims_id
+  alias_attribute :rims, :recirculating_infusion_mash_system
+
+  store_accessor :pins, :control_pin, :power_pin
+
+  validate :pin_match_validation
+  validate :control_pin_in_use_validation
+  validate :power_pin_in_use_validation
+
+  # == Sproutable Interface Methods ==
+  def rhizome_eid
+    control_pin
+  end
+
+  def rhizome_type_name
+    'heat'
+  end
+
+  def destroy_disabled?
+    !thermostat.nil? ||
+    (!thermostat.nil? && !thermostat.rims.nil?)
+  end
+
+end

--- a/app/models/pump.rb
+++ b/app/models/pump.rb
@@ -1,0 +1,32 @@
+require 'rhizome_sprout/rhizome_sprout'
+require 'validation_sets/relay_validations'
+
+class Pump < Equipment
+  include RhizomeSprout
+  include RelayValidations
+
+  belongs_to :recirculating_infusion_mash_system, validate: true,
+                                                  touch: true,
+                                                  foreign_key: :rims_id
+  alias_attribute :rims, :recirculating_infusion_mash_system
+
+  store_accessor :pins, :control_pin, :power_pin
+
+  validate :pin_match_validation
+  validate :control_pin_in_use_validation
+  validate :power_pin_in_use_validation
+
+  # == Sproutable Interface Methods ==
+  def rhizome_eid
+    control_pin
+  end
+
+  def rhizome_type_name
+    'pump'
+  end
+
+  def destroy_disabled?
+    !rims.nil?
+  end
+
+end

--- a/app/models/recirculating_infusion_mash_system.rb
+++ b/app/models/recirculating_infusion_mash_system.rb
@@ -1,0 +1,74 @@
+require 'rhizome_sprout/rhizome_sprout'
+
+class RecirculatingInfusionMashSystem < ActiveRecord::Base
+  include RhizomeSprout
+
+  has_one :sprout, as: :sproutable, dependent: :destroy
+  has_one :rhizome, through: :sprout
+
+  has_one :tube, class_name: 'Thermostat',
+          validate: true,
+          dependent: :destroy,
+          foreign_key: :rims_id,
+          inverse_of: :recirculating_infusion_mash_system
+  has_one :safety_sensor, class_name: 'TemperatureSensor',
+          validate: true,
+          dependent: :destroy,
+          foreign_key: :rims_id
+  has_one :recirculation_pump, class_name: 'Pump',
+          validate: true,
+          dependent: :destroy,
+          foreign_key: :rims_id
+
+  accepts_nested_attributes_for :tube, update_only: true
+  accepts_nested_attributes_for :safety_sensor, update_only: true
+  accepts_nested_attributes_for :recirculation_pump, update_only: true
+
+  validate :rhizome_must_match_validation
+  validates :tube, presence: true
+  validates :safety_sensor, presence: true
+  validates :recirculation_pump, presence: true
+
+  def rhizome_must_match_validation
+    unless tube.nil? || safety_sensor.nil? || recirculation_pump.nil?
+      unless tube.rhizome.nil? || safety_sensor.rhizome.nil? || recirculation_pump.rhizome.nil?
+        unless (tube.rhizome == safety_sensor.rhizome) && (tube.rhizome == recirculation_pump.rhizome)
+          errors.add(:tube, ', Safety Sensor, and Recirculation Pump must be registered as attached to the same Rhizome.')
+        end
+      end
+    end
+  end
+
+  def rhizome=(r)
+    super
+    tube.rhizome = r unless tube.nil?
+    safety_sensor.rhizome = r unless safety_sensor.nil?
+    recirculation_pump.rhizome = r unless recirculation_pump.nil?
+  end
+
+  def thermostat=(t)
+    super
+    tube.sensor.recirculating_infusion_mash_system = t.recirculating_infusion_mash_system unless tube.sensor.nil?
+    tube.element.recirculating_infusion_mash_system = t.recirculating_infusion_mash_system unless tube.element.nil?
+  end
+
+  def type
+    'RIMS'
+  end
+
+  def rhizome_type_name
+    'rims'
+  end
+
+  def rhizome_eid
+    tube.rhizome_eid
+  end
+
+  def build_subsystems
+    build_tube
+    tube.build_subsystems
+    build_safety_sensor
+    build_recirculation_pump
+  end
+
+end

--- a/app/models/rhizome.rb
+++ b/app/models/rhizome.rb
@@ -4,11 +4,60 @@ class Rhizome < ActiveRecord::Base
   # This sets up that relationship and makes it so we can pass Particle attribute changes through the
   # Rhizome's controller rather than building a full, separate controller just for the associated Particle.
   has_one :particle_device, inverse_of: :rhizome,
-                     dependent: :destroy
+                            dependent: :destroy
 
-  accepts_nested_attributes_for :particle_device
+  has_many :sprouts, dependent: :destroy
+  has_many :equipments, -> { distinct },
+                        through: :sprouts,
+                        source: :sproutable,
+                        source_type: 'Equipment'
+  delegate :pumps, :heating_elements, :temperature_sensors,
+           to: :equipments
+  has_many :thermostats, -> { distinct },
+           through: :sprouts,
+           source: :sproutable,
+           source_type: 'Thermostat',
+           after_add: :add_thermostat_children
+  has_many :recirculating_infusion_mash_systems, -> { distinct },
+           through: :sprouts,
+           source: :sproutable,
+           source_type: 'RecirculatingInfusionMashSystem',
+           after_add: :add_rims_children
+
+  accepts_nested_attributes_for :particle_device, update_only: true
 
   validates :name, presence: true,
                    length: { maximum: 50 }
+
+  # Provides a short-hand method for getting the various polymorphic
+  # equipment types connected to the Rhizome. Add the collection call
+  # when you add a new type.
+  def attached
+    [equipments, thermostats].flatten
+  end
+
+  def add_thermostat_children(t)
+    if t.is_a? Thermostat
+      equipments << t.element
+      equipments << t.sensor
+    end
+  end
+
+  def add_rims_children(t)
+    if t.is_a? RecirculatingInfusionMashSystem
+      add_thermostat_children(t.tube)
+      equipments << t.safety_sensor
+      equipments << t.recirculation_pump
+    end
+  end
+
+  class << self
+
+    # The digital pins supported by the Rhizome.
+    def digital_pins
+      [0, 1, 2, 3, 4, 5]
+    end
+
+  end
 
 end

--- a/app/models/sprout.rb
+++ b/app/models/sprout.rb
@@ -1,0 +1,10 @@
+class Sprout < ActiveRecord::Base
+
+  belongs_to :sproutable, polymorphic: true, dependent: :destroy
+  belongs_to :rhizome
+
+  def sproutable_type=(klass)
+    super(klass.to_s.classify.constantize.base_class.to_s)
+  end
+
+end

--- a/app/models/temperature_sensor.rb
+++ b/app/models/temperature_sensor.rb
@@ -1,0 +1,32 @@
+require 'rhizome_sprout/rhizome_sprout'
+
+class TemperatureSensor < Equipment
+  include RhizomeSprout
+
+  belongs_to :thermostat, validate: true, touch: true
+  belongs_to :recirculating_infusion_mash_system, validate: true,
+                                                  touch: true,
+                                                  foreign_key: :rims_id
+  alias_method :rims, :recirculating_infusion_mash_system
+
+  store_accessor :pins, :data_pin, :onewire_id
+
+  validates :onewire_id, presence: true, on: :update
+  validates :data_pin, presence: true, on: :update
+
+  # == Sproutable Interface Methods ==
+  def rhizome_eid
+    onewire_id
+  end
+
+  def rhizome_type_name
+    'temp'
+  end
+
+  def destroy_disabled?
+    !thermostat.nil? ||
+    !recirculating_infusion_mash_system.nil? ||
+    (!thermostat.nil? && !thermostat.recirculating_infusion_mash_system.nil?)
+  end
+
+end

--- a/app/models/thermostat.rb
+++ b/app/models/thermostat.rb
@@ -1,0 +1,66 @@
+require 'rhizome_sprout/rhizome_sprout'
+
+class Thermostat < ActiveRecord::Base
+  include RhizomeSprout
+
+  has_one :sprout, as: :sproutable, dependent: :destroy
+  has_one :rhizome, through: :sprout
+
+  has_one :element, class_name: 'HeatingElement',
+                    validate: true,
+                    dependent: :destroy
+  has_one :sensor, class_name: 'TemperatureSensor',
+                   validate: true,
+                   dependent: :destroy
+
+  belongs_to :recirculating_infusion_mash_system, validate: true,
+                                                  touch: true,
+                                                  inverse_of: :tube,
+                                                  foreign_key: :rims_id
+  alias_attribute :rims, :recirculating_infusion_mash_system
+
+  accepts_nested_attributes_for :element, update_only: true
+  accepts_nested_attributes_for :sensor, update_only: true
+
+  validate :rhizome_must_match_validation
+  validates :element, presence: true
+  validates :sensor, presence: true
+
+  def rhizome_must_match_validation
+    unless element.nil? || sensor.nil?
+      unless element.rhizome.nil? || sensor.rhizome.nil?
+        unless element.rhizome == sensor.rhizome
+          errors.add(:element, ' and Sensor must be registered as attached to the same Rhizome.')
+        end
+      end
+    end
+  end
+
+  def rhizome=(r)
+    super
+    element.rhizome = r unless element.nil?
+    sensor.rhizome = r unless sensor.nil?
+  end
+
+  def type
+    'Thermostat'
+  end
+
+  def rhizome_type_name
+    'therm'
+  end
+
+  def rhizome_eid
+    element.rhizome_eid
+  end
+
+  def build_subsystems
+    build_element
+    build_sensor
+  end
+
+  def destroy_disabled?
+    !rims.nil?
+  end
+
+end

--- a/app/serializers/hash_serializer.rb
+++ b/app/serializers/hash_serializer.rb
@@ -1,0 +1,17 @@
+# This serializer is based on Nando Vieira's blog post on JSONB in Rails:
+# http://nandovieira.com/using-postgresql-and-jsonb-with-ruby-on-rails
+class HashSerializer
+
+  class << self
+
+    def dump(hash)
+      hash.to_json
+    end
+
+    def load(hash)
+      (hash || {}).with_indifferent_access
+    end
+
+  end
+
+end

--- a/app/views/equipments/_add_equipment_dropdown.html.erb
+++ b/app/views/equipments/_add_equipment_dropdown.html.erb
@@ -1,0 +1,41 @@
+<% completer = rhizome.nil? ? '' : "-to-#{rhizome.id}" %>
+<span class="dropdown">
+  <a id="add-equipment<%= completer %>"
+     class="dropdown-toggle btn btn-sm btn-primary"
+     data-target="#"
+     data-toggle="dropdown"
+     aria-haspopup="true"
+     aria-expanded="false">
+    <% if rhizome.nil? %>
+        <span class="glyphicon glyphicon-plus"></span>
+    <% else %>
+        Add Equipment <span class="caret"></span>
+    <% end %>
+  </a>
+  <ul class="dropdown-menu" aria-labelledby="add-equipment<%= completer %>">
+    <% Equipment.equipment_types.each do |t| %>
+        <li>
+          <%= link_to t.titlecase,
+                      rhizome.nil? ? new_equipment_path(type: t) :
+                              new_equipment_path(rhizome: rhizome.id, type: t),
+                      alt: "Add #{t.titlecase}",
+                      title: "Add #{t.titlecase}" %>
+        </li>
+    <% end %>
+    <li class="divider"></li>
+    <li>
+      <%= link_to 'Thermostat',
+                  rhizome.nil? ? new_thermostat_path :
+                          new_thermostat_path(rhizome: rhizome.id),
+                  alt: 'Add Thermostat',
+                  title: 'Add Thermostat' %>
+    </li>
+    <li>
+      <%= link_to 'RIMS',
+                  rhizome.nil? ? new_recirculating_infusion_mash_system_path :
+                          new_recirculating_infusion_mash_system_path(rhizome: rhizome.id),
+                  alt: 'Add RIMS',
+                  title: 'Add RIMS' %>
+    </li>
+  </ul>
+</span>

--- a/app/views/equipments/_equipment.html.erb
+++ b/app/views/equipments/_equipment.html.erb
@@ -1,0 +1,27 @@
+<% disabler = equipment.thermostat.nil? ? '' : ' disabled' %>
+<tr>
+  <td><%= check_box_tag 'equipments[]', equipment.id, false, class: "equipment_checkbox#{disabler}" %></td>
+  <td><%= equipment.type.titlecase %></td>
+  <td>
+    <ul>
+    <% unless equipment.thermostat.nil? %>
+          <li>
+            <%= link_to "Thermostat #{equipment.thermostat.rhizome_eid}", equipment.thermostat %>
+          </li>
+    <% end %>
+    </ul>
+  </td>
+  <td>
+    <% if current_user.admin? %>
+        <%= link_to equipment,
+                    method: :delete,
+                    data: { confirm: "You sure you want to remove this #{equipment.type.titlecase}?" },
+                    class: "btn btn-sm btn-danger#{disabler}",
+                    id: "equipment-#{equipment.id}-destroy",
+                    alt: "Remove #{equipment.type.titlecase} ##{equipment.id}",
+                    title: "Remove #{equipment.type.titlecase} ##{equipment.id}" do %>
+            <span class="glyphicon glyphicon-trash"></span>
+        <% end %>
+    <% end %>
+  </td>
+</tr>

--- a/app/views/equipments/_equipment_list.html.erb
+++ b/app/views/equipments/_equipment_list.html.erb
@@ -1,0 +1,34 @@
+<%= form_for :equipment,
+             url: destroy_multiple_equipments_path,
+             method: :delete,
+             id: 'bulk-delete bulk-delete-equipments-form' do %>
+    <div class="table-responsive">
+      <%= will_paginate %>
+
+      <table class="equipments table table-hover table-striped">
+        <thead>
+        <tr>
+          <th>
+            <%= button_tag '',
+                           type: :submit,
+                           method: :delete,
+                           id: 'destroy-multiple-equipments',
+                           data: { confirm: 'You sure you want to remove all of these?' },
+                           class: 'btn btn-sm btn-primary glyphicon glyphicon-trash',
+                           alt: 'Remove Selected Equipment',
+                           title: 'Remove Selected Equipment' %>
+          </th>
+          <th>Type</th>
+          <th>Group</th>
+          <th>Pins</th>
+          <th>Actions</th>
+        </tr>
+        </thead>
+        <tbody>
+        <%= render e %>
+        </tbody>
+      </table>
+
+      <%= will_paginate %>
+    </div>
+<% end %>

--- a/app/views/equipments/_fields.html.erb
+++ b/app/views/equipments/_fields.html.erb
@@ -1,0 +1,20 @@
+<%= render 'shared/error_messages', object: f.object  %>
+
+<%= f.label :type %>
+<%= f.select :type,
+             Equipment.equipment_types.map { |et| [et.titlecase, et] },
+             {},
+             disabled: type != 'Equipment' || !object.attached?,
+             class: 'form-control' %>
+<% if type != 'Equipment' %>
+    <%= f.hidden_field :type, value: type %>
+<% end %>
+<% if rhizome.nil? %>
+    <%= f.label :rhizome %>
+    <%= f.select :rhizome,
+                 Rhizome.all.map { |r| [r.name, r.id] },
+                 {},
+                 class: 'form-control' %>
+<% else %>
+    <%= f.hidden_field :rhizome, value: rhizome.id %>
+<% end %>

--- a/app/views/equipments/edit.html.erb
+++ b/app/views/equipments/edit.html.erb
@@ -1,0 +1,15 @@
+<% provide(:title, "Edit #{@type.titlecase} #{rhizome_title_reference(@rhizome, :edit)}") %>
+<h1>Edit <%= @type.titlecase %> <%= rhizome_title_reference(@rhizome, :edit) %></h1>
+
+<div class="row">
+  <div class="col-md-6 col-md-offset-3">
+    <%= form_for(@equipment) do |f| %>
+        <%= render partial: 'fields', locals: {f: f, object: @equipment, type: @type, rhizome: @rhizome} %>
+        <% if @type != 'Equipment' %>
+            <%= render partial: "#{@type.pluralize.underscore}/pins", locals: {f: f} %>
+        <% end %>
+        <%= button_tag 'Save', type: :submit, class: 'btn btn-sm btn-primary' %>
+        <%= link_to 'Cancel', rhizomes_path, class: 'btn btn-sm btn-primary btn-danger' %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/equipments/index.html.erb
+++ b/app/views/equipments/index.html.erb
@@ -1,0 +1,8 @@
+<% provide(:title, "Manage #{@type == 'Equipment' ? @type : @type.titlecase.pluralize}") %>
+<h1>
+  Manage
+  <%= @type == 'Equipment' ? @type : @type.titlecase.pluralize %>
+  <%= render partial: 'equipments/add_equipment_dropdown', locals: {rhizome: nil} %>
+</h1>
+
+<%= render partial: 'equipment_list', locals: {e: @equipments, t: @type} %>

--- a/app/views/equipments/new.html.erb
+++ b/app/views/equipments/new.html.erb
@@ -1,0 +1,15 @@
+<% provide(:title, "Add #{@type.titlecase} #{rhizome_title_reference(@rhizome, :new)}") %>
+<h1>Add <%= @type.titlecase %> <%= rhizome_title_reference(@rhizome, :new) %></h1>
+
+<div class="row">
+  <div class="col-md-6 col-md-offset-3">
+    <%= form_for(@equipment) do |f| %>
+        <%= render partial: 'fields', locals: {f: f, object: @equipment, type: @type, rhizome: @rhizome} %>
+        <% if @type != 'Equipment' %>
+            <%= render partial: "#{@type.pluralize.underscore}/pins", locals: {f: f} %>
+        <% end %>
+        <%= button_tag 'Add', type: :submit, class: 'btn btn-sm btn-primary' %>
+        <%= link_to 'Cancel', rhizomes_path, class: 'btn btn-sm btn-primary btn-danger' %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/equipments/show.html.erb
+++ b/app/views/equipments/show.html.erb
@@ -1,0 +1,22 @@
+<% provide(:title, "#{@type.titlecase} ##{@equipment.id}") %>
+<div class="row">
+  <aside class="col-md-4">
+    <section class="equipment_info">
+      <h1>
+        <%= @type.titlecase %> #<%= @equipment.id %>
+      </h1>
+      <h4>
+        Pins:
+      </h4>
+      <% if @equipment.pins.length.zero? %>
+      <p>None</p>
+      <% else %>
+      <ul>
+        <% @equipment.pins.each do |k, v| %>
+            <li><%= k.titlecase %>: <%= v %></li>
+        <% end %>
+      </ul>
+      <% end %>
+    </section>
+  </aside>
+</div>

--- a/app/views/heating_elements/_heating_element.html.erb
+++ b/app/views/heating_elements/_heating_element.html.erb
@@ -1,0 +1,30 @@
+<% disabler = heating_element.destroy_disabled? ? ' disabled' : '' %>
+<tr>
+  <td><%= check_box_tag 'heating_elements[]',
+                        heating_element.id,
+                        false,
+                        class: "heating_element_checkbox#{disabler}",
+                        disabled: heating_element.destroy_disabled? %></td>
+  <td><%= heating_element.type.titlecase %></td>
+  <%= heating_element_group_column(heating_element) %>
+  <td><%= pins_list(heating_element) %></td>
+  <td>
+    <% if current_user.admin? %>
+        <%= link_to sti_equipment_type_path(heating_element.type, heating_element, :edit),
+                    class: 'btn btn-sm btn-info',
+                    alt: "Change Pins for #{heating_element.type.titlecase}",
+                    title: "Change Pins for #{heating_element.type.titlecase}" do %>
+            <span class="glyphicon glyphicon-wrench"></span>
+        <% end %>
+        <%= link_to heating_element,
+                    method: :delete,
+                    data: { confirm: "You sure you want to remove this #{heating_element.type.titlecase}?" },
+                    class: "btn btn-sm btn-danger#{disabler}",
+                    id: "equipment-#{heating_element.id}-destroy",
+                    alt: "Remove #{heating_element.type.titlecase} ##{heating_element.id}",
+                    title: "Remove #{heating_element.type.titlecase} ##{heating_element.id}" do %>
+            <span class="glyphicon glyphicon-trash"></span>
+        <% end %>
+    <% end %>
+  </td>
+</tr>

--- a/app/views/heating_elements/_pins.html.erb
+++ b/app/views/heating_elements/_pins.html.erb
@@ -1,0 +1,10 @@
+<%= f.label :control_pin %>
+<%= f.select :control_pin,
+             Rhizome.digital_pins.map { |et| ["D#{et}", et] },
+             {prompt: '--'},
+             class: 'form-control' %>
+<%= f.label :power_pin %>
+<%= f.select :power_pin,
+             Rhizome.digital_pins.map { |et| ["D#{et}", et] },
+             {prompt: '--'},
+             class: 'form-control' %>

--- a/app/views/layouts/_notifications.html.erb
+++ b/app/views/layouts/_notifications.html.erb
@@ -11,5 +11,8 @@
                content_tag(:span, '', id: 'flash-glyphicon', class: 'glyphicon glyphicon-info-sign')
            end %>
           <%= sanitize message %>
+        <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
     <% end %>
 <% end %>

--- a/app/views/pumps/_pins.html.erb
+++ b/app/views/pumps/_pins.html.erb
@@ -1,0 +1,10 @@
+<%= f.label :control_pin %>
+<%= f.select :control_pin,
+             Rhizome.digital_pins.map { |et| ["D#{et}", et] },
+             {prompt: '--'},
+             class: 'form-control' %>
+<%= f.label :power_pin %>
+<%= f.select :power_pin,
+             Rhizome.digital_pins.map { |et| ["D#{et}", et] },
+             {prompt: '--'},
+             class: 'form-control' %>

--- a/app/views/pumps/_pump.html.erb
+++ b/app/views/pumps/_pump.html.erb
@@ -1,0 +1,30 @@
+<% disabler = pump.destroy_disabled? ? ' disabled' : '' %>
+<tr>
+  <td><%= check_box_tag 'pumps[]',
+                        pump.id,
+                        false,
+                        class: "pump_checkbox#{disabler}",
+                        disabled: pump.destroy_disabled? %></td>
+  <td><%= pump.type.titlecase %></td>
+  <%= pump_group_column(pump) %>
+  <td><%= pins_list(pump) %></td>
+  <td>
+    <% if current_user.admin? %>
+        <%= link_to sti_equipment_type_path(pump.type, pump, :edit),
+                    class: 'btn btn-sm btn-info',
+                    alt: "Change Pins for #{pump.type.titlecase}",
+                    title: "Change Pins for #{pump.type.titlecase}" do %>
+            <span class="glyphicon glyphicon-wrench"></span>
+        <% end %>
+        <%= link_to pump,
+                    method: :delete,
+                    data: { confirm: "You sure you want to remove this #{pump.type.titlecase}?" },
+                    class: "btn btn-sm btn-danger#{disabler}",
+                    id: "equipment-#{pump.id}-destroy",
+                    alt: "Remove #{pump.type.titlecase}",
+                    title: "Remove #{pump.type.titlecase}" do %>
+            <span class="glyphicon glyphicon-trash"></span>
+        <% end %>
+    <% end %>
+  </td>
+</tr>

--- a/app/views/recirculating_infusion_mash_systems/_fields.html.erb
+++ b/app/views/recirculating_infusion_mash_systems/_fields.html.erb
@@ -1,0 +1,30 @@
+<%= render 'shared/error_messages', object: f.object  %>
+
+<% if rhizome.nil? %>
+    <%= f.label :rhizome %>
+    <%= f.select :rhizome,
+                 Rhizome.all.map { |r| [r.name, r.id] },
+                 {},
+                 class: 'form-control' %>
+<% else %>
+    <%= f.hidden_field :rhizome, value: rhizome.id %>
+<% end %>
+<h4><%= f.label :tube, 'Tube' %></h4>
+<%= f.fields_for :tube do |p| %>
+    <h5><%= p.label :element, 'Heating Element' %></h5>
+    <%= p.fields_for :element do |ep| %>
+        <%= render partial: 'heating_elements/pins', locals: {f: ep} %>
+    <% end %>
+    <h5><%= p.label :sensor, 'Temperature Sensor' %></h5>
+    <%= p.fields_for :sensor do |tsp| %>
+        <%= render partial: 'temperature_sensors/pins', locals: {f: tsp} %>
+    <% end %>
+<% end %>
+<h4><%= f.label :safety_sensor, 'Safety Sensor' %></h4>
+<%= f.fields_for :safety_sensor do |p| %>
+    <%= render partial: 'temperature_sensors/pins', locals: {f: p} %>
+<% end %>
+<h4><%= f.label :recirculation_pump, 'Recirculation Pump' %></h4>
+<%= f.fields_for :recirculation_pump do |p| %>
+    <%= render partial: 'pumps/pins', locals: {f: p} %>
+<% end %>

--- a/app/views/recirculating_infusion_mash_systems/_pins_list.html.erb
+++ b/app/views/recirculating_infusion_mash_systems/_pins_list.html.erb
@@ -1,0 +1,23 @@
+<ul>
+  <li>
+    Tube:
+    <ul>
+      <li>
+        Heating Element:
+        <%= pins_list(rims.tube.element) %>
+      </li>
+      <li>
+        Temperature Sensor:
+        <%= pins_list(rims.tube.sensor) %>
+      </li>
+    </ul>
+  </li>
+  <li>
+    Safety Sensor:
+    <%= pins_list(rims.safety_sensor) %>
+  </li>
+  <li>
+    Recirculation Pump:
+    <%= pins_list(rims.recirculation_pump) %>
+  </li>
+</ul>

--- a/app/views/recirculating_infusion_mash_systems/_recirculating_infusion_mash_system.html.erb
+++ b/app/views/recirculating_infusion_mash_systems/_recirculating_infusion_mash_system.html.erb
@@ -1,0 +1,29 @@
+<tr>
+  <td><%= check_box_tag 'recirculating_infusion_mash_systems[]',
+                        recirculating_infusion_mash_system.id,
+                        false,
+                        class: 'recirculating_infusion_mash_system_checkbox' %></td>
+  <td><%= recirculating_infusion_mash_system.type %></td>
+  <td>
+    <%= render partial: 'pins_list', locals: {rims: recirculating_infusion_mash_system} %>
+  </td>
+  <td>
+    <% if current_user.admin? %>
+        <%= link_to edit_recirculating_infusion_mash_system_path(recirculating_infusion_mash_system),
+                    class: 'btn btn-sm btn-info',
+                    alt: "Change Pins for RIMS ##{recirculating_infusion_mash_system.rhizome_eid}",
+                    title: "Change Pins for RIMS ##{recirculating_infusion_mash_system.rhizome_eid}" do %>
+            <span class="glyphicon glyphicon-wrench"></span>
+        <% end %>
+        <%= link_to recirculating_infusion_mash_system,
+                    method: :delete,
+                    data: { confirm: 'You sure you want to remove this RIMS?' },
+                    class: 'btn btn-sm btn-danger',
+                    id: "rims-#{recirculating_infusion_mash_system.id}-destroy",
+                    alt: "Remove RIMS ##{recirculating_infusion_mash_system.rhizome_eid}",
+                    title: "Remove RIMS ##{recirculating_infusion_mash_system.rhizome_eid}" do %>
+            <span class="glyphicon glyphicon-trash"></span>
+        <% end %>
+    <% end %>
+  </td>
+</tr>

--- a/app/views/recirculating_infusion_mash_systems/edit.html.erb
+++ b/app/views/recirculating_infusion_mash_systems/edit.html.erb
@@ -1,0 +1,12 @@
+<% provide(:title, 'Edit RIMS') %>
+<h1>Edit RIMS</h1>
+
+<div class="row">
+  <div class="col-md-6 col-md-offset-3">
+    <%= form_for(@recirculating_infusion_mash_system) do |f| %>
+        <%= render partial: 'fields', locals: {f: f, object: @recirculating_infusion_mash_system, rhizome: @rhizome} %>
+        <%= button_tag 'Save', type: :submit, class: 'btn btn-sm btn-primary' %>
+        <%= js_back_button(:cancel) %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/recirculating_infusion_mash_systems/index.html.erb
+++ b/app/views/recirculating_infusion_mash_systems/index.html.erb
@@ -1,0 +1,42 @@
+<% provide(:title, 'Manage RIMS') %>
+<h1>
+  Manage RIMS <%= link_to '',
+                          new_recirculating_infusion_mash_system_path,
+                          class: 'btn btn-sm btn-primary glyphicon glyphicon-plus',
+                          alt: 'Add a RIMS',
+                          title: 'Add a RIMS' %>
+</h1>
+
+<%= form_for :recirculating_infusion_mash_system,
+             url: destroy_multiple_recirculating_infusion_mash_systems_path,
+             method: :delete,
+             id: 'bulk-delete bulk-delete-rims-form' do %>
+    <div class="table-responsive">
+      <%= will_paginate %>
+
+      <table class="rims table table-hover table-striped">
+        <thead>
+        <tr>
+          <th>
+            <%= button_tag '',
+                           type: :submit,
+                           method: :delete,
+                           id: 'destroy-multiple-rims',
+                           data: { confirm: 'You sure you want to remove all of these?' },
+                           class: 'btn btn-sm btn-primary glyphicon glyphicon-trash',
+                           alt: 'Remove Selected RIMS',
+                           title: 'Remove Selected RIMS' %>
+          </th>
+          <th>Type</th>
+          <th>Pins</th>
+          <th>Actions</th>
+        </tr>
+        </thead>
+        <tbody>
+        <%= render @recirculating_infusion_mash_systems %>
+        </tbody>
+      </table>
+
+      <%= will_paginate %>
+    </div>
+<% end %>

--- a/app/views/recirculating_infusion_mash_systems/new.html.erb
+++ b/app/views/recirculating_infusion_mash_systems/new.html.erb
@@ -1,0 +1,12 @@
+<% provide(:title, 'Add RIMS') %>
+<h1>Add RIMS</h1>
+
+<div class="row">
+  <div class="col-md-6 col-md-offset-3">
+    <%= form_for(@recirculating_infusion_mash_system) do |f| %>
+        <%= render partial: 'fields', locals: {f: f, object: @recirculating_infusion_mash_system, rhizome: @rhizome} %>
+        <%= button_tag 'Add', type: :submit, class: 'btn btn-sm btn-primary' %>
+        <%= js_back_button(:cancel) %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/recirculating_infusion_mash_systems/show.html.erb
+++ b/app/views/recirculating_infusion_mash_systems/show.html.erb
@@ -1,0 +1,28 @@
+<% provide(:title, "RIMS #{@recirculating_infusion_mash_system.rhizome_eid}") %>
+<div class="row">
+  <aside class="col-md-4">
+    <section class="equipment_info">
+      <h1>
+        RIMS <%= @recirculating_infusion_mash_system.rhizome_eid %>
+      </h1>
+      <h4>
+        Pins:
+      </h4>
+      <%= render partial: 'pins_list', locals: {rims: @recirculating_infusion_mash_system} %>
+    </section>
+    <%= link_to 'Edit',
+                edit_thermostat_path,
+                id: @recirculating_infusion_mash_system.id,
+                class: 'btn btn-sm btn-primary',
+                alt: 'Edit',
+                title: 'Edit' %>
+    <%= link_to 'Delete',
+                @recirculating_infusion_mash_system,
+                method: :delete,
+                data: { confirm: 'You sure?' },
+                class: 'btn btn-sm btn-danger',
+                alt: 'Delete',
+                title: 'Delete' %>
+    <%= js_back_button %>
+  </aside>
+</div>

--- a/app/views/rhizomes/_equipment.html.erb
+++ b/app/views/rhizomes/_equipment.html.erb
@@ -1,0 +1,4 @@
+<div>
+  <h3 class="center">Equipment</h3>
+  <%= render partial: 'equipments/equipment_list', locals: {e: rhizome.equipments, t: 'Equipment'} %>
+</div>

--- a/app/views/rhizomes/_rhizome.html.erb
+++ b/app/views/rhizomes/_rhizome.html.erb
@@ -53,7 +53,7 @@
                     class: 'btn btn-sm btn-success',
                     alt: "Turn on Heating Element 1 for #{rhizome.name}",
                     title: "Turn on Heating Element 1 for #{rhizome.name}" do %>
-            <span class="glyphicon glyphicon-candle"></span>
+            <span class="glyphicon glyphicon-fire"></span>
         <% end %>
         <%= link_to heating_element_path(id: rhizome.particle_device.id, heat_id: 1, task: :off),
                     method: :post,

--- a/app/views/rhizomes/modals/_show.html.erb
+++ b/app/views/rhizomes/modals/_show.html.erb
@@ -10,14 +10,15 @@
           <li><span class="rhizome show_info">Device ID:</span> <%= rhizome.particle_device.device_id %></li>
           <li><span class="rhizome show_info">Access Token:</span> <%= rhizome.particle_device.access_token %></li>
         </ul>
+        <%= render partial: 'rhizomes/equipment', locals: {rhizome: rhizome} %>
       </div>
       <div class="modal-footer">
         <%= link_to 'Edit',
                     edit_rhizome_path(id: rhizome.id),
-                    id: rhizome.id,
                     class: 'btn btn-sm btn-primary',
                     alt: 'Edit',
                     title: 'Edit' %>
+        <%= render partial: 'equipments/add_equipment_dropdown', locals: {rhizome: rhizome} %>
         <%= link_to 'Delete',
                     rhizome,
                     method: :delete,

--- a/app/views/rhizomes/show.html.erb
+++ b/app/views/rhizomes/show.html.erb
@@ -9,6 +9,7 @@
         <li><span class="rhizome show_info">Name:</span> <%= @rhizome.name %></li>
         <li><span class="rhizome show_info">Device ID:</span> <%= @rhizome.particle_device.device_id %></li>
         <li><span class="rhizome show_info">Access Token:</span> <%= @rhizome.particle_device.access_token %></li>
+        <!-- TODO: Add a way to display the Equipment attached to the Rhizome from its non-modal :show page -->
       </ul>
     </section>
     <%= link_to 'Edit',
@@ -17,6 +18,7 @@
                 class: 'btn btn-sm btn-primary',
                 alt: 'Edit',
                 title: 'Edit' %>
+    <%= render partial: 'equipments/add_equipment_dropdown', locals: {rhizome: @rhizome} %>
     <%= link_to 'Delete',
                 @rhizome,
                 method: :delete,

--- a/app/views/temperature_sensors/_pins.html.erb
+++ b/app/views/temperature_sensors/_pins.html.erb
@@ -1,0 +1,7 @@
+<%= f.label :data_pin %>
+<%= f.select :data_pin,
+             Rhizome.digital_pins.map { |et| ["D#{et}", et] },
+             {prompt: '--'},
+             class: 'form-control' %>
+<%= f.label :onewire_id, 'OneWire ID' %>
+<%= f.text_field :onewire_id %>

--- a/app/views/temperature_sensors/_temperature_sensor.html.erb
+++ b/app/views/temperature_sensors/_temperature_sensor.html.erb
@@ -1,0 +1,30 @@
+<% disabler = temperature_sensor.destroy_disabled? ? ' disabled' : '' %>
+<tr>
+  <td><%= check_box_tag 'temperature_sensors[]',
+                        temperature_sensor.id,
+                        false,
+                        class: "temperature_sensor_checkbox#{disabler}",
+                        disabled: temperature_sensor.destroy_disabled? %></td>
+  <td><%= temperature_sensor.type.titlecase %></td>
+  <%= temperature_sensor_group_column(temperature_sensor) %>
+  <td><%= pins_list(temperature_sensor) %></td>
+  <td>
+    <% if current_user.admin? %>
+        <%= link_to sti_equipment_type_path(temperature_sensor.type, temperature_sensor, :edit),
+                    class: 'btn btn-sm btn-info',
+                    alt: "Change Pins for #{temperature_sensor.type.titlecase}",
+                    title: "Change Pins for #{temperature_sensor.type.titlecase}" do %>
+            <span class="glyphicon glyphicon-wrench"></span>
+        <% end %>
+        <%= link_to temperature_sensor,
+                    method: :delete,
+                    data: { confirm: "You sure you want to remove this #{temperature_sensor.type.titlecase}?" },
+                    class: "btn btn-sm btn-danger#{disabler}",
+                    id: "equipment-#{temperature_sensor.id}-destroy",
+                    alt: "Remove #{temperature_sensor.type.titlecase}",
+                    title: "Remove #{temperature_sensor.type.titlecase}" do %>
+            <span class="glyphicon glyphicon-trash"></span>
+        <% end %>
+    <% end %>
+  </td>
+</tr>

--- a/app/views/thermostats/_fields.html.erb
+++ b/app/views/thermostats/_fields.html.erb
@@ -1,0 +1,19 @@
+<%= render 'shared/error_messages', object: f.object  %>
+
+<% if rhizome.nil? %>
+    <%= f.label :rhizome %>
+    <%= f.select :rhizome,
+                 Rhizome.all.map { |r| [r.name, r.id] },
+                 {},
+                 class: 'form-control' %>
+<% else %>
+    <%= f.hidden_field :rhizome, value: rhizome.id %>
+<% end %>
+<h5><%= f.label :element, 'Heating Element' %></h5>
+<%= f.fields_for :element do |p| %>
+    <%= render partial: 'heating_elements/pins', locals: {f: p} %>
+<% end %>
+<h5><%= f.label :sensor, 'Temperature Sensor' %></h5>
+<%= f.fields_for :sensor do |p| %>
+    <%= render partial: 'temperature_sensors/pins', locals: {f: p} %>
+<% end %>

--- a/app/views/thermostats/_pins_list.html.erb
+++ b/app/views/thermostats/_pins_list.html.erb
@@ -1,0 +1,10 @@
+<ul>
+  <li>
+    Heating Element:
+    <%= pins_list(thermostat.element) %>
+  </li>
+  <li>
+    Temperature Sensor:
+    <%= pins_list(thermostat.sensor) %>
+  </li>
+</ul>

--- a/app/views/thermostats/_thermostat.html.erb
+++ b/app/views/thermostats/_thermostat.html.erb
@@ -1,0 +1,24 @@
+<tr>
+  <td><%= check_box_tag 'thermostats[]', thermostat.id, false, class: 'thermostat_checkbox' %></td>
+  <td><%= thermostat.type.titlecase %></td>
+  <td><%= render partial: 'pins_list', locals: {thermostat: @thermostat} %></td>
+  <td>
+    <% if current_user.admin? %>
+        <%= link_to edit_thermostat_path(thermostat),
+                    class: 'btn btn-sm btn-info',
+                    alt: "Change Pins for Thermostat ##{thermostat.rhizome_eid}",
+                    title: "Change Pins for Thermostat ##{thermostat.rhizome_eid}" do %>
+            <span class="glyphicon glyphicon-wrench"></span>
+        <% end %>
+        <%= link_to thermostat,
+                    method: :delete,
+                    data: { confirm: 'You sure you want to remove this Thermostat?' },
+                    class: 'btn btn-sm btn-danger',
+                    id: "thermostat-#{thermostat.id}-destroy",
+                    alt: "Remove Thermostat ##{thermostat.rhizome_eid}",
+                    title: "Remove Thermostat ##{thermostat.rhizome_eid}" do %>
+            <span class="glyphicon glyphicon-trash"></span>
+        <% end %>
+    <% end %>
+  </td>
+</tr>

--- a/app/views/thermostats/edit.html.erb
+++ b/app/views/thermostats/edit.html.erb
@@ -1,0 +1,12 @@
+<% provide(:title, 'Edit Thermostat') %>
+<h1>Edit Thermostat</h1>
+
+<div class="row">
+  <div class="col-md-6 col-md-offset-3">
+    <%= form_for(@thermostat) do |f| %>
+        <%= render partial: 'fields', locals: {f: f, object: @thermostat, rhizome: @rhizome} %>
+        <%= button_tag 'Save', type: :submit, class: 'btn btn-sm btn-primary' %>
+        <%= js_back_button(:cancel) %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/thermostats/index.html.erb
+++ b/app/views/thermostats/index.html.erb
@@ -1,0 +1,42 @@
+<% provide(:title, 'Manage Thermostats') %>
+<h1>
+  Manage Thermostats <%= link_to '',
+                                new_thermostat_path,
+                                class: 'btn btn-sm btn-primary glyphicon glyphicon-plus',
+                                alt: 'Add a Thermostat',
+                                title: 'Add a Thermostat' %>
+</h1>
+
+<%= form_for :thermostat,
+             url: destroy_multiple_thermostats_path,
+             method: :delete,
+             id: 'bulk-delete bulk-delete-thermostats-form' do %>
+    <div class="table-responsive">
+      <%= will_paginate %>
+
+      <table class="thermostats table table-hover table-striped">
+        <thead>
+        <tr>
+          <th>
+            <%= button_tag '',
+                           type: :submit,
+                           method: :delete,
+                           id: 'destroy-multiple-thermostats',
+                           data: { confirm: 'You sure you want to remove all of these?' },
+                           class: 'btn btn-sm btn-primary glyphicon glyphicon-trash',
+                           alt: 'Remove Selected Thermostat',
+                           title: 'Remove Selected Thermostat' %>
+          </th>
+          <th>Type</th>
+          <th>Pins</th>
+          <th>Actions</th>
+        </tr>
+        </thead>
+        <tbody>
+        <%= render @thermostats %>
+        </tbody>
+      </table>
+
+      <%= will_paginate %>
+    </div>
+<% end %>

--- a/app/views/thermostats/new.html.erb
+++ b/app/views/thermostats/new.html.erb
@@ -1,0 +1,12 @@
+<% provide(:title, 'Add Thermostat') %>
+<h1>Add Thermostat</h1>
+
+<div class="row">
+  <div class="col-md-6 col-md-offset-3">
+    <%= form_for(@thermostat) do |f| %>
+        <%= render partial: 'fields', locals: {f: f, object: @thermostat, rhizome: @rhizome} %>
+        <%= button_tag 'Add', type: :submit, class: 'btn btn-sm btn-primary' %>
+        <%= js_back_button(:cancel) %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/thermostats/show.html.erb
+++ b/app/views/thermostats/show.html.erb
@@ -1,0 +1,29 @@
+<% disabler = @thermostat.destroy_disabled? ? ' disabled' : '' %>
+<% provide(:title, "Thermostat #{@thermostat.rhizome_eid}") %>
+<div class="row">
+  <aside class="col-md-4">
+    <section class="equipment_info">
+      <h1>
+        Thermostat <%= @thermostat.rhizome_eid %>
+      </h1>
+      <h4>
+        Pins:
+      </h4>
+      <%= render partial: 'pins_list', locals: {thermostat: @thermostat} %>
+    </section>
+    <%= link_to 'Edit',
+                edit_thermostat_path,
+                id: @thermostat.id,
+                class: 'btn btn-sm btn-primary',
+                alt: 'Edit',
+                title: 'Edit' %>
+    <%= link_to 'Delete',
+                @thermostat,
+                method: :delete,
+                data: { confirm: 'You sure?' },
+                class: "btn btn-sm btn-danger#{disabler}",
+                alt: 'Delete',
+                title: 'Delete' %>
+    <%= js_back_button %>
+  </aside>
+</div>

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -9,6 +9,11 @@
 #   inflect.irregular 'person', 'people'
 #   inflect.uncountable %w( fish sheep )
 # end
+ActiveSupport::Inflector.inflections(:en) do |inflect|
+  # This is more for practicality than anything. Otherwise, our migration and model for Equipment gets confused.
+  # Just be wary when trying to auto-generate text on a page.
+  inflect.irregular 'equipment', 'equipments'
+end
 
 # These inflection rules are supported but not enabled by default:
 # ActiveSupport::Inflector.inflections(:en) do |inflect|

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,6 +22,30 @@ Rails.application.routes.draw do
     resources :hooks, only: [:index, :new, :create, :destroy]
   end
 
+  resources :equipments
+  resources :equipments do
+    collection do
+      delete :destroy_multiple
+    end
+  end
+  resources :equipment, controller: 'equipments', type: 'Equipment' # Compensates for the janky pluralization
+  resources :pumps, controller: 'equipments', type: 'Pump'
+  resources :heating_elements, controller: 'equipments', type: 'HeatingElement'
+  resources :temperature_sensors, controller: 'equipments', type: 'TemperatureSensor'
+  resources :thermostats
+  resources :thermostats do
+    collection do
+      delete :destroy_multiple
+    end
+  end
+  resources :recirculating_infusion_mash_systems
+  resources :recirculating_infusion_mash_systems do
+    collection do
+      delete :destroy_multiple
+    end
+  end
+  resources :rims, controller: 'recirculating_infusion_mash_systems' # Compensates for the stupid-long name
+
   scope :jobs, controller: :jobs, shallow: true do
     post 'ping'
     post 'pump'

--- a/db/migrate/20151008003134_create_equipments.rb
+++ b/db/migrate/20151008003134_create_equipments.rb
@@ -1,0 +1,19 @@
+class CreateEquipments < ActiveRecord::Migration
+  def change
+
+    # This is our join table to connect Rhizomes to various forms of Equipment
+    create_table :sprouts do |t|
+      t.references :rhizome
+      t.references :sproutable, polymorphic: true, index: true
+    end
+
+    # Equipment is an STI base class, so we need to provide a type.
+    # Each subclass has 0+ pins, so we'll use a JSONB column for flexibility.
+    create_table :equipments do |t|
+      t.string  :type
+      t.jsonb   :pins, null: false, default: '{}', index: true, using: :gin
+      t.timestamps null: false
+    end
+
+  end
+end

--- a/db/migrate/20151014034502_create_thermostats.rb
+++ b/db/migrate/20151014034502_create_thermostats.rb
@@ -1,0 +1,9 @@
+class CreateThermostats < ActiveRecord::Migration
+  def change
+    create_table :thermostats do |t|
+      t.timestamps null: false
+    end
+
+    add_reference :equipments, :thermostat, index: true
+  end
+end

--- a/db/migrate/20151016060732_create_recirculating_infusion_mash_systems.rb
+++ b/db/migrate/20151016060732_create_recirculating_infusion_mash_systems.rb
@@ -1,0 +1,11 @@
+class CreateRecirculatingInfusionMashSystems < ActiveRecord::Migration
+  def change
+    create_table :recirculating_infusion_mash_systems do |t|
+
+      t.timestamps null: false
+    end
+
+    add_reference :equipments, :rims, index: true
+    add_reference :thermostats, :rims, index: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151007014640) do
+ActiveRecord::Schema.define(version: 20151016060732) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -32,14 +32,27 @@ ActiveRecord::Schema.define(version: 20151007014640) do
 
   add_index "delayed_jobs", ["priority", "run_at"], name: "delayed_jobs_priority", using: :btree
 
+  create_table "equipments", force: :cascade do |t|
+    t.string   "type"
+    t.jsonb    "pins",          default: {}, null: false
+    t.datetime "created_at",                 null: false
+    t.datetime "updated_at",                 null: false
+    t.integer  "thermostat_id"
+    t.integer  "rims_id"
+  end
+
+  add_index "equipments", ["pins"], name: "index_equipments_on_pins", using: :btree
+  add_index "equipments", ["rims_id"], name: "index_equipments_on_rims_id", using: :btree
+  add_index "equipments", ["thermostat_id"], name: "index_equipments_on_thermostat_id", using: :btree
+
   create_table "heating_element_statuses", force: :cascade do |t|
     t.string   "device_id"
     t.integer  "heat_id"
     t.string   "state"
     t.datetime "stop_time"
     t.integer  "voltage"
-    t.datetime "created_at",         null: false
-    t.datetime "updated_at",         null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "particle_devices", force: :cascade do |t|
@@ -62,6 +75,11 @@ ActiveRecord::Schema.define(version: 20151007014640) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "recirculating_infusion_mash_systems", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "rhizomes", force: :cascade do |t|
     t.string   "name",        null: false
     t.datetime "created_at",  null: false
@@ -70,6 +88,14 @@ ActiveRecord::Schema.define(version: 20151007014640) do
   end
 
   add_index "rhizomes", ["particle_id"], name: "index_rhizomes_on_particle_id", using: :btree
+
+  create_table "sprouts", force: :cascade do |t|
+    t.integer "rhizome_id"
+    t.integer "sproutable_id"
+    t.string  "sproutable_type"
+  end
+
+  add_index "sprouts", ["sproutable_type", "sproutable_id"], name: "index_sprouts_on_sproutable_type_and_sproutable_id", using: :btree
 
   create_table "temperature_sensor_statuses", force: :cascade do |t|
     t.string   "device_id"
@@ -81,6 +107,14 @@ ActiveRecord::Schema.define(version: 20151007014640) do
     t.datetime "created_at",     null: false
     t.datetime "updated_at",     null: false
   end
+
+  create_table "thermostats", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer  "rims_id"
+  end
+
+  add_index "thermostats", ["rims_id"], name: "index_thermostats_on_rims_id", using: :btree
 
   create_table "users", force: :cascade do |t|
     t.string   "name",            limit: 255

--- a/lib/rhizome_sprout/rhizome_sprout.rb
+++ b/lib/rhizome_sprout/rhizome_sprout.rb
@@ -1,0 +1,51 @@
+# == Sprout Interface methods ==
+# Using this module to extend your model should allow you to interact with the Rhizome.
+#
+# For this to work, your model needs:
+# rhizome : A reference the Rhizome you'd like to send messages to
+# type : The standardized type name for the Equipment you're attaching, such as "Pump" or "RIMS"
+# rhizome_eid : The Equipment ID of the Equipment instance on the Rhizome side
+# rhizome_type : The Equipment Type of the Equipment instance on the Rhizome side
+#
+# The combination of the Rhizome and the Equipment ID represent a unique key that identifies the
+# particular piece of Equipment amongst all Equipment that Ohmbrewer knows of. This information makes it fairly simple to
+# determine the appropriate endpoint(s) to connect to.
+module RhizomeSprout
+
+  # Provides the expected identifier on the Rhizome's side for the Equipment
+  def rhizome_eid
+    NotImplementedError 'No Rhizome Equipment ID method provided!'
+  end
+
+  # Provides the expected identifier on the Rhizome's side for the Equipment Type name
+  def rhizome_type_name
+    NotImplementedError 'No Rhizome Equipment Type method provided!'
+  end
+
+  # Produces a String of arguments formatted in the way that the Particle Function on the Rhizome expects
+  def to_args_str(current_task='', state='', stop_time='')
+    "#{rhizome_eid},#{current_task},#{state},#{stop_time}"
+  end
+
+  # The name of Particle Function for updating this Equipment instance
+  def update_function_name
+    "#{rhizome_type_name}_#{rhizome_eid}"
+  end
+
+  # Sends the provided information to the Rhizome's appropriate Particle Function endpoint.
+  def send_update(current_task='', state='', stop_time='')
+    Rails.logger.info "Sending a message to the #{type} of: " <<
+                      "#{to_args_str(current_task, state, stop_time)}"
+    begin
+      rhizome.particle_device
+             .connection
+             .function update_function_name,
+                       to_args_str(current_task, state, stop_time)
+    rescue Particle::BadRequest => e
+      msg = "Lost contact with Rhizome or the Rhizome doesn't support " <<
+            "the \"#{update_function_name}\" function! Check your equipment!"
+      Rails.logger.error msg
+    end
+  end
+
+end

--- a/lib/validation_sets/relay_validations.rb
+++ b/lib/validation_sets/relay_validations.rb
@@ -1,0 +1,38 @@
+# == Relay Validations ==
+# These are some standard validations that will apply to Equipment based on the Relay class in the Rhizome firmware.
+module RelayValidations
+
+  # Ensures that the control pin and the power pin are set to different values or no value.
+  def pin_match_validation
+    if (control_pin == power_pin) && control_pin != ''
+      errors.add(:control_pin, ' may not be the same as the Power Pin.')
+    end
+  end
+
+  # Determines if a given pin is currently in use for the Rhizome that the
+  # Equipment will be attached to.
+  # @param [Integer] pin The pin number
+  # @return [True|False] Whether the pin is in use
+  def pin_in_use?(pin)
+    if rhizome.nil? || rhizome.equipments.nil? || rhizome.equipments.empty?
+      false
+    else
+      unless pin.blank?
+        rhizome.equipments
+               .select{|e| e.id != id }
+               .any? {|e| e.pins[:control_pin] == pin || e.pins[:power_pin] == pin || e.pins[:data_pin] == pin}
+      end
+    end
+  end
+
+  # Ensures that the assigned control pin is not already in use.
+  def control_pin_in_use_validation
+    errors.add(:control_pin, ' is already in use.') if pin_in_use? control_pin
+  end
+
+  # Ensures that the assigned power pin is not already in use.
+  def power_pin_in_use_validation
+    errors.add(:power_pin, ' is already in use.') if pin_in_use? power_pin
+  end
+
+end

--- a/test/controllers/equipment_controller_test.rb
+++ b/test/controllers/equipment_controller_test.rb
@@ -1,0 +1,39 @@
+require 'test_helper'
+
+class EquipmentControllerTest < ActionController::TestCase
+  test "should get index" do
+    get :index
+    assert_response :success
+  end
+
+  test "should get show" do
+    get :show
+    assert_response :success
+  end
+
+  test "should get new" do
+    get :new
+    assert_response :success
+  end
+
+  test "should get edit" do
+    get :edit
+    assert_response :success
+  end
+
+  test "should get create" do
+    get :create
+    assert_response :success
+  end
+
+  test "should get update" do
+    get :update
+    assert_response :success
+  end
+
+  test "should get destroy" do
+    get :destroy
+    assert_response :success
+  end
+
+end

--- a/test/controllers/recirculating_infusion_mash_systems_controller_test.rb
+++ b/test/controllers/recirculating_infusion_mash_systems_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class RecirculatingInfusionMashSystemsControllerTest < ActionController::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/controllers/thermostats_controller_test.rb
+++ b/test/controllers/thermostats_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class ThermostatsControllerTest < ActionController::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/equipments.yml
+++ b/test/fixtures/equipments.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined.  If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+#  column: value

--- a/test/fixtures/recirculating_infusion_mash_systems.yml
+++ b/test/fixtures/recirculating_infusion_mash_systems.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined.  If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+#  column: value

--- a/test/fixtures/thermostats.yml
+++ b/test/fixtures/thermostats.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined.  If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+#  column: value

--- a/test/models/equipment_test.rb
+++ b/test/models/equipment_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class EquipmentTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/recirculating_infusion_mash_system_test.rb
+++ b/test/models/recirculating_infusion_mash_system_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class RecirculatingInfusionMashSystemTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/thermostat_test.rb
+++ b/test/models/thermostat_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class ThermostatTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
@Ohmbrewer/web-team Check this out when you get a chance (sooner rather than later, though).

This provides an initial, simple way to manage the pin settings on your Rhizomes via the Rhizome management page.

It took a little bit to get in place because I had to learn a bit about how Rails does inheritance and devise a plan that made sense for our approach. What I came up with is this:
- We'll use Single Table Inheritance (STI) for the basic Equipment types (Pump, HeatingElement, and TemperatureSensor)
- Thermostat and RIMS will be similar to how they are in the Rhizome - composites of other types mostly. Here we'll implement a shared interface with Equipment via a module (RhizomeSprout) that provides duck-typing methods.
- We'll use a Polymorphic has_many :through association (sproutable) to connect the Rhizome class to Equipment, Thermostat, and RIMS.

As you'll see here, I've already implemented the associations and the Equipment-based types. This got big quick, so I'm going to do the Thermostat and/or RIMS implementations in separate PRs. However, as-is this should provide a jumping off point for creating the Tasks and Jobs necessary for implementing the scheduler if someone ends up starting on that early.

I'll also add in an issue for back-filling tests as they're lacking here. You'll note that as part of the RhizomeSprout module, I've provided a method for sending an update to the Rhizome. I was able to manually verify (via the rails console) that the method does work as intended - the message transmitted and toggled a Pump's ON/OFF display. Similarly, I've manually walked through the UI interactions.

Let me know if you have any questions. Otherwise, I'll probably merge this in tomorrow night or the next day.
