### PR TITLE
Adds the ability to run a simple Schedule.

### DIFF
--- a/app/jobs/schedule_job.rb
+++ b/app/jobs/schedule_job.rb
@@ -1,0 +1,60 @@
+class ScheduleJob < ActiveJob::Base
+  # Note that this is the default schedule queue.
+  # Our ScheduleJob should probably set a more specific
+  # queue when creating the ScheduleJob.
+  queue_as :schedule
+
+  # Processes a given Schedule
+  # @param [Schedule] schedule The Schedule to process
+  def perform(schedule)
+
+    Rails.logger.info '======================================='
+    Rails.logger.info "Starting schedule \"#{schedule.name}\"!"
+    Rails.logger.info '======================================='
+
+    # Launch the root task. All other tasks will be launched via triggers on the state machine.
+    TaskJob.set(queue: schedule.root_task.queue_name).perform_later(schedule.root_task)
+    Rails.logger.info "Queuing root task: #{schedule.root_task.type} ##{schedule.root_task.id}"
+
+    # While there are more tasks to perform, we'll keep on performin' them...
+    until schedule.all_tasks_complete?
+
+      # # Override any tasks that are blocking a triggered task.
+      # # We should end up with the last possible task.
+      # # Note: This will short-circuit any triggers after the current state,
+      # #       which may mean some Tasks down the line won't get triggered!
+      # #       Hence, if we know a task will override we should make it the
+      # #       parent rather than the task it will override.
+      # schedule.queued_tasks.each do |task|
+      #   # Stop the overridden task (task in the named queue with the oldest run_at time)
+      #   overridden_task = Delayed::Job.where(queue_name: task.queue_name)
+      #                                 .order(run_at: :desc)
+      #                                 .first
+      #
+      #   # Don't dequeue a blocking task
+      #   next if overridden_task.blocking?
+      #
+      #   Rails.logger.info "Dequeuing overridden task: #{overridden_task.type} ##{overridden_task.id}"
+      #   overridden_task.override_and_dequeue
+      # end
+
+      # Requeue any tasks that have failed
+      schedule.failed_tasks.each do |task|
+        TaskJob.set(queue: task.queue_name).perform_later(task)
+        Rails.logger.info "Requeuing #{task.type} ##{task.id}"
+      end
+
+      # Take a nap...
+      sleep 15
+      schedule.reload
+
+    end
+
+    Rails.logger.info '======================================='
+    Rails.logger.info "Finished Schedule \"#{schedule.name}\"!"
+    Rails.logger.info '======================================='
+
+  end
+
+
+end

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -8,33 +8,69 @@ class Schedule < ActiveRecord::Base
   # == Validators ==
   validates :root_task, presence: true,
                         on: :update,
-                        unless: 'tasks.empty?'
+                        unless: 'tasks.empty? || tasks.none?{ |t| !t.id.nil? }'
 
   # == Instance Methods ==
+
+  # Whether the Schedule is in a state where it can be processed by a ScheduleJob.
+  # So far, the requirements are:
+  # 1) The root task is set
+  # 2) All tasks other than the root task have a parent
+  # @return [TrueFalse] True if the Schedule can be run
+  def runnable?
+    !root_task.nil? &&
+    tasks.all? { |t| t == root_task ? true : (!t.parent.nil?) }
+  end
 
   # The list of Tasks that are currently processing
   # @return [Array[Task]] The list of running tasks
   def running_tasks
-    raise NotImplementedError, 'Not ready yet!'
+    tasks.select { |t| !t.done? && !t.queued? && !t.failed? }
+  end
+
+  # The list of Tasks that have been triggered but are blocked waiting for processing
+  # @return [Array[Task]] The list of running tasks
+  def queued_tasks
+    tasks.select { |t| t.queued? }
   end
 
   # The list of Tasks that are done
   # @return [Array[Task]] The list of running tasks
   def complete_tasks
-    raise NotImplementedError, 'Not ready yet!'
+    tasks.select { |t| t.done? }
+  end
+
+  # The list of Tasks that are done
+  # @return [Array[Task]] The list of running tasks
+  def all_tasks_complete?
+    complete_tasks.length == tasks.length
   end
 
   # The list of Tasks that are ready to be passed into a Job
   # @return [Array[Task]] The list of running tasks
   def next_tasks
-    raise NotImplementedError, 'Not ready yet!'
+    running_tasks.select { |t| t.children }
   end
 
   # The list of Tasks associated with failed jobs.
   # These will need to be handled appropriately (e.g. restarted).
   # @return [Array[Task]] The list of running tasks
   def failed_tasks
-    raise NotImplementedError, 'Not ready yet!'
+    tasks.select { |t| t.failed? }
+  end
+
+  # The list of Tasks queued on a given equipment instance
+  # @param [Equipment] equipment The equipment in question
+  # @return [Array[Task]] The list of tasks queued for that Equipment
+  def tasks_queued_for_equipment(equipment)
+    queued_tasks.select { |t| (t.equipment == equipment) }
+  end
+
+  # The list of Tasks queued on a given equipment instance
+  # @param [Equipment] equipment The equipment in question
+  # @return [Array[Task]] The list of tasks running on that Equipment
+  def tasks_running_on_equipment(equipment)
+    running_tasks.select { |t| (t.equipment == equipment) }
   end
 
 end

--- a/app/views/schedules/_schedule.html.erb
+++ b/app/views/schedules/_schedule.html.erb
@@ -6,6 +6,13 @@
   </td>
   <td>
     <% if current_user.admin? %>
+        <%= link_to schedule_run_path(schedule),
+                    method: :post,
+                    class: "btn btn-sm btn-success#{schedule.runnable? ? '' : ' disabled'}",
+                    alt: "Run #{schedule.name}",
+                    title: "Run #{schedule.name}" do %>
+            <span class="glyphicon glyphicon-play-circle"></span>
+        <% end %>
         <%= link_to schedule_duplicate_path(schedule),
                     method: :post,
                     class: 'btn btn-sm btn-primary',

--- a/app/views/schedules/_task_fields.html.erb
+++ b/app/views/schedules/_task_fields.html.erb
@@ -30,17 +30,17 @@
         </span>
     </div>
     <div class="input-group">
-    <span class="input-group-addon">after</span>
+    <span class="input-group-addon">after Task</span>
+      <%= f.label :parent_id, 'Parent Task', class: 'sr-only' %>
+      <%= f.select :parent_id,
+                   Task.where(schedule_id: f.object.schedule_id).map { |t| ["##{t.id}", t.id] },
+                   {include_blank: true, selected: (f.object.nil? ? '' : f.object.parent_id)},
+                   class: 'form-control' %>
+    <span class="input-group-addon">is</span>
     <%= f.label :trigger, class: 'sr-only' %>
     <%= f.select :trigger,
-                 Task.triggers.map { |t, _| [t.titlecase, t] },
+                 Task.triggers.map { |t, _| [t.gsub('on_', '').titlecase, t] },
                  {include_blank: true, selected: (f.object.trigger.nil? ? '' : f.object.trigger)},
-                 class: 'form-control' %>
-    <span class="input-group-addon">fires for Task</span>
-    <%= f.label :parent_id, 'Parent Task', class: 'sr-only' %>
-    <%= f.select :parent_id,
-                 Task.where(schedule_id: f.object.schedule_id).map { |t| ["##{t.id}", t.id] },
-                 {include_blank: true, selected: (f.object.nil? ? '' : f.object.parent_id)},
                  class: 'form-control' %>
 
     </div>

--- a/app/views/schedules/_task_list.html.erb
+++ b/app/views/schedules/_task_list.html.erb
@@ -4,19 +4,26 @@
   <% else %>
       <% schedule.root_task.self_and_descendants.each do |task| %>
       <li>
-        <span class="label label-success">
+        <span class="label label-primary">
+        <%= link_to ' ',
+                    task_run_path(task),
+                    method: :post,
+                    class: 'text-danger glyphicon glyphicon-off',
+                    alt: "Run Task ##{task.id} Isolated",
+                    title: "Run Task ##{task.id} Isolated" %>
           <% if task.id == schedule.root_task.id %>
               <span class="glyphicon glyphicon-flash"></span>
           <% end %>
           Task #<%= task.id %>:
-        </span><br />
-        <span class="label label-primary"><%= task.type_name_display %></span>
+        </span>
+        <br />
+        <span class="label label-success"><%= task.type_name_display %></span>
         <% unless task.equipment.nil? %>
             <span class="label label-default"><%= task.equipment.type.titlecase %> #<%= task.equipment.rhizome_eid %></span>
             for <span class="label label-warning"><%= task.duration %> sec.</span>
             <% unless task.parent.nil? %>
-                after <span class="label label-danger"><%= task.trigger.titlecase %></span>
-                fires for <span class="label label-success">Task #<%= task.parent.id %></span>
+                after <span class="label label-primary">Task #<%= task.parent.id %></span>
+                is <span class="label label-danger"><%= task.trigger_name_display %></span>
             <% end %>
         <% end %>
       </li>

--- a/app/views/schedules/modals/_show.html.erb
+++ b/app/views/schedules/modals/_show.html.erb
@@ -3,12 +3,28 @@
     <div class="modal-content">
       <div class="modal-header navbar-inverse">
         <%= button_tag '', class: 'btn btn-sm btn-danger glyphicon glyphicon-remove', 'data-dismiss' => 'modal' %>
-        <h4 class="modal-title" id="schedule-<%= schedule.id %>-show-label"><%= schedule.name %></h4>
+        <h4 class="modal-title" id="schedule-<%= schedule.id %>-show-label"><%= schedule.name %>
+        <% if schedule.runnable? %>
+            <span class="label label-sm label-success">
+              <span class="glyphicon glyphicon-ok-circle"></span>
+            </span>
+        <% else %>
+            <span class="label label-sm label-danger">
+              <span class="glyphicon glyphicon-ban-circle"></span>
+            </span>
+        <% end %>
+        </h4>
       </div>
       <div class="modal-body schedule-info">
         <%= render partial: 'schedules/task_list', locals: {schedule: schedule} %>
       </div>
       <div class="modal-footer">
+        <%= link_to 'Run',
+                    schedule_run_path(schedule),
+                    method: :post,
+                    class: "btn btn-sm btn-success#{schedule.runnable? ? '' : ' disabled'}",
+                    alt: "Run #{schedule.name}",
+                    title: "Run #{schedule.name}" %>
         <%= link_to 'Edit',
                     edit_schedule_path(id: schedule.id),
                     class: 'btn btn-sm btn-primary',

--- a/app/views/schedules/show.html.erb
+++ b/app/views/schedules/show.html.erb
@@ -1,12 +1,29 @@
 <% provide(:title, @schedule.name) %>
 <div class="row">
-  <aside class="col-md-4">
+  <aside class="col-md-8">
     <section class="schedule_info">
       <h1>
         <%= @schedule.name %>
       </h1>
+      <% if @schedule.runnable? %>
+            <span class="label label-sm label-success">
+              <span class="glyphicon glyphicon-ok-circle"></span>
+              Ready to Run
+            </span>
+      <% else %>
+            <span class="label label-sm label-danger">
+              <span class="glyphicon glyphicon-ban-circle"></span>
+              Not Ready to Run
+            </span>
+      <% end %>
       <%= render partial: 'task_list', locals: {schedule: @schedule} %>
     </section>
+    <%= link_to 'Run',
+                schedule_run_path(@schedule),
+                method: :post,
+                class: "btn btn-sm btn-success#{@schedule.runnable? ? '' : ' disabled'}",
+                alt: "Run #{@schedule.name}",
+                title: "Run #{@schedule.name}" %>
     <%= link_to 'Edit',
                 edit_schedule_path,
                 id: @schedule.id,

--- a/config/application.rb
+++ b/config/application.rb
@@ -22,8 +22,5 @@ module Ohmbrewer
 
     # Do not swallow errors in after_commit/after_rollback callbacks.
     config.active_record.raise_in_transactional_callbacks = true
-
-    # Use Delayed Job for ActiveJob
-    config.active_job.queue_adapter = :delayed_job
   end
 end

--- a/config/initializers/active_job.rb
+++ b/config/initializers/active_job.rb
@@ -1,0 +1,2 @@
+# Use Delayed Job for ActiveJob
+Ohmbrewer::Application.config.active_job.queue_adapter = :delayed_job

--- a/config/initializers/delayed_job.rb
+++ b/config/initializers/delayed_job.rb
@@ -1,0 +1,5 @@
+# Options
+Delayed::Worker.destroy_failed_jobs = false
+Delayed::Worker.max_run_time = 5.hour # We'll want to bump this up when we're ready to run longer processes (e.g. fermentation)
+Delayed::Worker.delay_jobs = !Rails.env.test?
+Delayed::Worker.logger = Logger.new(File.join(Rails.root, 'log', 'delayed_job.log'))

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,9 +25,15 @@ Rails.application.routes.draw do
   resources :schedules
   resources :schedules do
     post 'duplicate' => 'schedules#duplicate'
+    post 'run'       => 'jobs#schedule'
+    post 'run_task'  => 'jobs#task'
     collection do
       delete :destroy_multiple
     end
+  end
+
+  resources :tasks do
+    post 'run'  => 'jobs#task'
   end
 
   resources :recipes

--- a/db/migrate/20151108220410_enable_uuid_extension.rb
+++ b/db/migrate/20151108220410_enable_uuid_extension.rb
@@ -1,0 +1,5 @@
+class EnableUuidExtension < ActiveRecord::Migration
+  def change
+    enable_extension 'uuid-ossp'
+  end
+end

--- a/db/migrate/20151108220411_add_job_id_to_task.rb
+++ b/db/migrate/20151108220411_add_job_id_to_task.rb
@@ -1,0 +1,7 @@
+class AddJobIdToTask < ActiveRecord::Migration
+  def change
+
+    add_column :tasks, :job_id, :uuid, index: true
+
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,10 +11,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151104235604) do
+ActiveRecord::Schema.define(version: 20151108220411) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+  enable_extension "uuid-ossp"
 
   create_table "delayed_jobs", force: :cascade do |t|
     t.integer  "priority",               default: 0, null: false
@@ -126,6 +127,7 @@ ActiveRecord::Schema.define(version: 20151104235604) do
     t.integer  "parent_id"
     t.integer  "sort_order"
     t.integer  "trigger"
+    t.uuid     "job_id"
   end
 
   add_index "tasks", ["schedule_id"], name: "index_tasks_on_schedule_id", using: :btree

--- a/lib/rhizome_interfaces/sprout/heating_element_sprout.rb
+++ b/lib/rhizome_interfaces/sprout/heating_element_sprout.rb
@@ -6,8 +6,6 @@ module RhizomeInterfaces
     # This automagically adds the ClassMethods to the ClassMethods of Sprout
     def self.included(base)
       base.extend(ClassMethods)
-      interceptor = const_set("#{base.name}Interceptor", Module.new)
-      base.prepend interceptor
     end
 
     # == Class Methods to Include ==

--- a/lib/rhizome_interfaces/sprout/pump_sprout.rb
+++ b/lib/rhizome_interfaces/sprout/pump_sprout.rb
@@ -6,8 +6,6 @@ module RhizomeInterfaces
     # This automagically adds the ClassMethods to the ClassMethods of Sprout
     def self.included(base)
       base.extend(ClassMethods)
-      interceptor = const_set("#{base.name}Interceptor", Module.new)
-      base.prepend interceptor
     end
 
     # == Class Methods to Include ==

--- a/lib/rhizome_interfaces/sprout/rims_sprout.rb
+++ b/lib/rhizome_interfaces/sprout/rims_sprout.rb
@@ -6,8 +6,6 @@ module RhizomeInterfaces
     # This automagically adds the ClassMethods to the ClassMethods of Sprout
     def self.included(base)
       base.extend(ClassMethods)
-      interceptor = const_set("#{base.name}Interceptor", Module.new)
-      base.prepend interceptor
     end
 
     # == Class Methods to Include ==

--- a/lib/rhizome_interfaces/sprout/temperature_sensor_sprout.rb
+++ b/lib/rhizome_interfaces/sprout/temperature_sensor_sprout.rb
@@ -6,8 +6,6 @@ module RhizomeInterfaces
     # This automagically adds the ClassMethods to the ClassMethods of Sprout
     def self.included(base)
       base.extend(ClassMethods)
-      interceptor = const_set("#{base.name}Interceptor", Module.new)
-      base.prepend interceptor
     end
 
     # == Class Methods to Include ==
@@ -20,6 +18,14 @@ module RhizomeInterfaces
       # @return [Equipment|Thermostat|Recirculating_Infusion_Mash_System] The sprout instance
       def find_by_rhizome_eid(rhizome, rhizome_eid)
         rhizome.temperature_sensors.select {|p| p.rhizome_eid.to_i == rhizome_eid }.first
+      end
+
+      # Formats a String of additional arguments to supplement the defaults in #to_args_str
+      # @abstract This method must be implemented to pass those extra arguments.
+      # @param extra [Hash] Hash of extra arguments
+      # @return [String] The extra arguments, ready for appending
+      def parse_extra_args(extra={})
+        ''
       end
 
     end

--- a/lib/rhizome_interfaces/sprout/thermostat_sprout.rb
+++ b/lib/rhizome_interfaces/sprout/thermostat_sprout.rb
@@ -6,8 +6,6 @@ module RhizomeInterfaces
     # This automagically adds the ClassMethods to the ClassMethods of Sprout
     def self.included(base)
       base.extend(ClassMethods)
-      interceptor = const_set("#{base.name}Interceptor", Module.new)
-      base.prepend interceptor
     end
 
     # == Class Methods to Include ==


### PR DESCRIPTION
Should resolve #48 .

Now, if you have some workers running (at least one for each queue), you can process a schedule.

Notes:
- We don't handle ramping (e.g. Thermostat) jobs yet, but once we make one, I think it'll work...
- I've added some stuff to support overriding a job as a new job comes in for the same equipment. The actual overriding mechanism in ScheduleJob is commented out, but it should be close. Until we get that, Tasks for the same equipment will block. That isn't a problem if you're not ramping and all the durations in your schedule add up correctly, but we want to be more robust than that in the future.
- The actual message-sending is still commented out and will probably stay that way until we resolve #47 . It means we're not getting feedback from the Rhizome, but we can mock the status messages (if we need them) by manually adding them via the console.
- I added some little "On" icons in the labels for the Tasks in the Schedule viewer that can be clicked to manually submit the single Task job. That's for testing purposes - it only sends the one Task and doesn't travel the schedule. In the long term, we'll drop that feature but it's handy for the time being (not unlike the Run Schedule button itself).

@Ohmbrewer/web-team Per usual, gonna leave this up for ~24 hours for perusal and then merge to master.
