### PR TITLE
Gets the Bootstrap modal -based confirmation dialog working again.

### DIFF
--- a/app/assets/javascripts/confirmation_dialog.coffee
+++ b/app/assets/javascripts/confirmation_dialog.coffee
@@ -1,0 +1,32 @@
+## Based off of
+## http://stackoverflow.com/questions/26289601/rails-4-1-4-custom-confirmation-alert
+$ ->
+  $.rails.allowAction = (link) ->
+    return true unless link.attr('data-confirm')
+    $.rails.showConfirmDialog(link)
+    false
+
+  $.rails.confirmed = (link) ->
+    link.removeAttr('data-confirm')
+    link.trigger('click.rails')
+
+  $.rails.showConfirmDialog = (link) ->
+    message = link.attr 'data-confirm'
+    html = """
+<div class="modal" id="confirmationDialog">
+ <div class="modal-dialog">
+   <div class="modal-content">
+     <div class="modal-header navbar-inverse">
+       <button class="btn btn-sm btn-danger glyphicon glyphicon-remove" data-dismiss="modal" />
+       <h4><i class="glyphicon glyphicon-warning-sign"></i>  #{message}</h4>
+     </div>
+     <div class="modal-footer">
+       <a data-dismiss="modal" class="btn btn-danger">Cancel</a>
+       <a data-dismiss="modal" class="btn btn-primary confirm">Delete</a>
+     </div>
+   </div>
+ </div>
+</div>
+           """
+    $(html).modal()
+    $('#confirmationDialog .confirm').on 'click', -> $.rails.confirmed(link)


### PR DESCRIPTION
Resolves #26 .

Or rather it will shortly... This isn't actually quite ready for merge yet. It does get the confirmation dialogs working again, however it breaks the multiple delete functionality. I'm not quite sure how to get around that, so I'm putting this up in case someone has idea how to do it.

Also makes the Name required when creating a Schedule. Not sure why that wasn't already a thing.
