### PR TITLE
Refactors our Schedule Gantt chart to use the google_visualr gem.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,9 @@ gem 'puma'
 # Twitter Bootstrap
 gem 'bootstrap-sass', '3.3.3'
 
+# Includes Google Charts via google_visualr
+gem 'google_visualr', git: 'https://github.com/kyleoliveira/google_visualr.git' #'~> 2.5', '>= 2.5.1'
+
 # Form fancification
 gem 'cocoon', '1.2.6'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,9 @@
+GIT
+  remote: https://github.com/kyleoliveira/google_visualr.git
+  revision: 35ed31770d0a9aff767fc3c534844f4aaae24bda
+  specs:
+    google_visualr (2.5.1)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -245,6 +251,7 @@ DEPENDENCIES
   daemons
   delayed_job_active_record
   faker (= 1.4.2)
+  google_visualr!
   jbuilder (~> 2.0)
   jquery-rails
   particlerb

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,6 +4,9 @@
   <title><%= full_title(yield(:title)) %></title>
   <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true %>
   <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
+  <!-- TODO: It would be great if we could limit loading of this to specific controllers/actions -->
+  <%= javascript_include_tag 'https://www.gstatic.com/charts/loader.js' %>
+
   <%= favicon_link_tag %>
   <%= csrf_meta_tags %>
   <%= render 'layouts/shim' %>

--- a/app/views/recipes/show.html.erb
+++ b/app/views/recipes/show.html.erb
@@ -1,6 +1,6 @@
 <% provide(:title, "#{@recipe.name} | #{@type.titlecase}") %>
 <div class="row">
-  <aside class="col-md-4">
+  <aside class="col-md-10">
     <section class="recipe_info">
       <h1>
         <%= @recipe.name %>

--- a/app/views/schedules/_task_list.html.erb
+++ b/app/views/schedules/_task_list.html.erb
@@ -1,52 +1,10 @@
-<html>
-<head>
-  <script type="text/javascript" src="https://www.gstatic.com/charts/loader.js"></script>
-  <script type="text/javascript">
-
-    google.charts.load('current', {'packages':['gantt']});
-    google.charts.setOnLoadCallback(drawChart);
-    
-    function toMilliseconds(minutes) {
-      return minutes * 60 * 1000;
-    }
-
-    function drawChart() {
-
-      var data = new google.visualization.DataTable();
-      var timeline = <%= raw schedule.timeline.to_json %>
-
-      data.addColumn('string', 'Task ID');
-      data.addColumn('string', 'Task Name');
-      data.addColumn('string', 'Resource');
-      data.addColumn('date', 'Start Date');
-      data.addColumn('date', 'End Date');
-      data.addColumn('number', 'Duration');
-      data.addColumn('number', 'Percent Complete');
-      data.addColumn('string', 'Dependencies');
-
-      for (i = 0; i < timeline.length; i++) {
-        var start_date = timeline[i][3];
-        timeline[i][3] = new Date(start_date);
-      }
-      data.addRows(timeline);
-      //need to translate ruby array task.trigger_start to new Date(milliseconds) for this to render correctly
-      var options = {
-        height: 275,
-        gantt: {
-          defaultStartDateMillis: new Date()
-        }
-      };
-
-      var chart = new google.visualization.Gantt(document.getElementById('chart_div'));
-
-      chart.draw(data, options);
-    }
-  </script>
-</head>
-<body>
-  <div id="chart_div", style="width: 80%"></div>
-</body>
-</html>
-
-
-
+  <div id='chart'></div>
+  <% if schedule.chartable? %>
+    <%= render_chart(schedule.to_gantt, 'chart') %>
+  <% end %>
+  <h5><span class="label label-info">Note:</span></h5>
+  <% if schedule.chartable? %>
+      <span class="glyphicon glyphicon-asterisk"></span> All times are based on starting the batch right now.
+  <% else %>
+      <span class="glyphicon glyphicon-asterisk"></span> This schedule cannot be charted! Either there is no root task or no task with a duration longer than 0 seconds.
+  <% end %>

--- a/app/views/schedules/show.html.erb
+++ b/app/views/schedules/show.html.erb
@@ -1,6 +1,6 @@
 <% provide(:title, @schedule.name) %>
 <div class="row">
-  <aside class="col-md-8">
+  <aside class="col-md-10">
     <section class="schedule_info">
       <h1>
         <%= @schedule.name %>


### PR DESCRIPTION
Adds visualization for ramping tasks and simplifies the calculation of start/end times for tasks by simply providing the duration and letting Google Charts figure out things based on dependencies.

Right now, you'll notice that the Gemfile is pointing at a GitHub repo I've made by forking google_visualr. This is because the Google Charts api changed since the last time the gem maintainer updated the gem (last September). I figured out what needs to be fixed to get it rolling again, and I've put in a pull request (winston/google_visualr#102), so hopefully that'll get pulled into the mainline sometime soon. When/if that happens, we'll just remove the git reference and set the gem to the correct version.

This change should make it easier/cleaner to work with Google Charts going forward, which is going to be important when we start implementing the dashboard.

@kathomas921 Take a look at this when you get a chance, and let me know what you think. I rearranged the actual chart elements a little bit, but I feel like it provides more useful information this way. You should try it out combinations of off/on tasks, RunThermostatTasks, and one or more tasks that start on Ramping, just to see what happens.
