### PR TITLE
Updates the specified Ruby version to 2.3.0.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-ruby '2.2.1'
+ruby '2.3.0'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '4.2.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -272,7 +272,7 @@ DEPENDENCIES
   puma
   rails (= 4.2.1)
   rails_12factor
-  rubocop
+  rubocop (~> 0.39.0)
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)
   test-factory (~> 0.5.3)
@@ -284,5 +284,8 @@ DEPENDENCIES
   will_paginate (= 3.0.7)
   yard
 
+RUBY VERSION
+   ruby 2.3.0p0
+
 BUNDLED WITH
-   1.11.2
+   1.12.5

--- a/app/helpers/equipments_helper.rb
+++ b/app/helpers/equipments_helper.rb
@@ -33,7 +33,7 @@ module EquipmentsHelper
         content_tag(:li, 'Not Set')
       else
         equipment.pins.each do |k, v|
-          unless v.nil? || v.empty?
+          unless v.nil?
             concat content_tag(:li, "#{k.titlecase}: #{v}")
           end
         end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -76,14 +76,15 @@ t1 = TurnOnTask.create!(
   duration: 60,
   )
 
-t2 = TurnOnTask.create!(
-  status: :queued,
-  equipment_id: eq2.id,
-  schedule_id: sched.id,
-  duration: 15,
-  parent_id: t1.id,
-  trigger: :on_started
-  )
+# TODO: Fix this so that it doesn't cause db:setup to fail
+# t2 = TurnOnTask.create!(
+#   status: :queued,
+#   equipment_id: eq2.id,
+#   schedule_id: sched.id,
+#   duration: 15,
+#   parent_id: t1.id,
+#   trigger: :on_started
+#   )
 
 sched[:root_task_id] = t1.id
 sched.save


### PR DESCRIPTION
Also: 
- Disables one of the Task seeds because it is breaking db:setup 
- Removed an empty? check in the pins_list method that caused an error when trying to display the Equipment Profiles index page.

@Ohmbrewer/web-team If nobody complains or merges it, I'll do so in ~24 hours.
