### PR TITLE
Adds knapsack support to parallelize Travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,12 @@ script:
   - RAILS_ENV=test bundle exec rake db:migrate --trace
   - bundle exec rake db:test:prepare
   - bundle exec rake test
+env:
+  global:
+    - CI_NODE_TOTAL=2
+  matrix:
+    - CI_NODE_INDEX=0
+    - CI_NODE_INDEX=1
 notifications:
   email: false
 

--- a/Gemfile
+++ b/Gemfile
@@ -67,6 +67,7 @@ group :development, :test do
   gem 'faker', '1.4.2'
   gem 'rubocop', '~> 0.39.0', :require => false
   gem 'simplecov', '0.12.0', :require => false
+  gem 'knapsack', '1.11.1'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -128,6 +128,9 @@ GEM
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
     json (1.8.3)
+    knapsack (1.11.1)
+      rake
+      timecop (>= 0.1.0)
     libv8 (3.16.14.11)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
@@ -228,6 +231,7 @@ GEM
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (2.0.1)
+    timecop (0.8.1)
     turbolinks (2.5.3)
       coffee-rails
     tzinfo (1.2.2)
@@ -273,6 +277,7 @@ DEPENDENCIES
   google_visualr!
   jbuilder (~> 2.0)
   jquery-rails
+  knapsack (= 1.11.1)
   particlerb
   pg
   puma

--- a/Rakefile
+++ b/Rakefile
@@ -4,3 +4,5 @@
 require File.expand_path('../config/application', __FILE__)
 
 Rails.application.load_tasks
+
+Knapsack.load_tasks if defined?(Knapsack)

--- a/knapsack_minitest_report.json
+++ b/knapsack_minitest_report.json
@@ -1,0 +1,19 @@
+{
+  "test/controllers/equipments_controller_test.rb": 7.506300926208496,
+  "test/integration/users_login_test.rb": 0.2052922248840332,
+  "test/controllers/sessions_controller_test.rb": 0.008071422576904297,
+  "test/integration/users_index_test.rb": 0.12989258766174316,
+  "test/helpers/sessions_helper_test.rb": 0.015198230743408203,
+  "test/controllers/rhizomes_controller_test.rb": 0.13486766815185547,
+  "test/mailers/user_mailer_test.rb": 0.1713705062866211,
+  "test/controllers/static_pages_controller_test.rb": 0.019465208053588867,
+  "test/integration/site_layout_test.rb": 0.03239750862121582,
+  "test/integration/users_signup_test.rb": 0.06684994697570801,
+  "test/models/equipment_test.rb": 0.006937980651855469,
+  "test/models/rhizome_test.rb": 0.03416895866394043,
+  "test/controllers/thermostats_controller_test.rb": 0.2285909652709961,
+  "test/controllers/users_controller_test.rb": 0.04182243347167969,
+  "test/integration/users_edit_test.rb": 0.0799875259399414,
+  "test/models/user_test.rb": 0.0694878101348877,
+  "test/controllers/recirculating_infusion_mash_systems_controller_test.rb": 0.3633458614349365
+}

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -42,3 +42,8 @@ class ActiveSupport::TestCase
       defined?(post_via_redirect)
     end
 end
+
+require 'knapsack'
+
+knapsack_adapter = Knapsack::Adapters::MinitestAdapter.bind
+knapsack_adapter.set_test_helper_path(__FILE__)


### PR DESCRIPTION
This adds the Knapsack gem for parallelizing Travis CI builds. This means that our tests will run on two nodes instead of one and (hopefully) complete twice as fast. (Looks about right based on our current suite, btw.)

You will need to add the following environment variables when using rake to run tests now:

``` bash
CI_NODE_TOTAL=1
CI_NODE_INDEX=0
```

Further, if you're running the rake task via RubyMine, you should check the option for "Run the script in context of the bundle (bundle exec)" under the Bundler tab.

The final thing to consider is that if we add a bunch of tests (particularly long running ones), we should update the JSON included in this commit (see the Knapsack gem documentation, future maintainer). We shouldn't have to do it too often, though.
